### PR TITLE
Cache all the things

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -28,9 +28,44 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.16
+      - uses: actions/cache@v2
+        with:
+          key: ${{ runner.OS }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
-
       - name: Unit test
         run: make test
+
+  build:
+    name: "build"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - name: Setup buildx instance
+        uses: docker/setup-buildx-action@v1
+        with:
+          use: true
+      - uses: actions/cache@v2
+        with:
+          key: ${{ runner.OS }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+      - uses: crazy-max/ghaction-github-runtime@v1
+      - name: Build main
+        run: make docker-build CACHE_FROM=type=gha,scope=eraser-manager CACHE_TO=type=gha,scope=eraser-manager,mode=max
+      - name: Build eraser
+        run: make docker-build-eraser CACHE_FROM=type=gha,scope=eraser-node CACHE_TO=type=gha,scope=eraser-node,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,9 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN \
+    --mount=type=cache,target=/root/gocache \
+    GOCACHE=/root/gocache CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,14 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+ifdef CACHE_TO
+_CACHE_TO := --cache-to $(CACHE_TO)
+endif
+
+ifdef CACHE_FROM
+_CACHE_FROM := --cache-from $(CACHE_FROM)
+endif
+
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
@@ -64,13 +72,13 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	docker buildx build $(_CACHE_FROM) $(_CACHE_TO) -t ${IMG} .
 
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
 
 docker-build-eraser:
-	docker build -t ashnam/remove_images:latest . -f pkg/eraser/Dockerfile
+	docker buildx build $(_CACHE_FROM) $(_CACHE_TO) -t ashnam/remove_images:latest . -f pkg/eraser/Dockerfile
 docker-push-eraser:
 	docker push ashnam/remove_images:latest
 

--- a/pkg/eraser/Dockerfile
+++ b/pkg/eraser/Dockerfile
@@ -2,9 +2,14 @@ FROM golang:1.16 AS build
 
 WORKDIR /src
 
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
 COPY . .
 
-RUN cd pkg/eraser && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-w -extldflags "-static"' -o /out/removal .
+RUN \
+    --mount=type=cache,target=/root/gocache \
+    cd pkg/eraser && GOCACHE=/root/gocache CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-w -extldflags "-static"' -o /out/removal .
 
 RUN chmod +x /out/removal
 


### PR DESCRIPTION
This adds cache mounts for the go build cach which makes repeated
builds, even with changes to the source, use Go's caching mechanism.

Also adds builds to the CI to ensure Dockerfile's aren't broken.
This uses github actions as a cache backend for buildkit.

Signed-off-by: Brian Goff <cpuguy83@gmail.com>