### PR TITLE
Add image prune

### DIFF
--- a/pkg/eraser/eraser.go
+++ b/pkg/eraser/eraser.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -76,6 +78,9 @@ func (c *client) deleteImage(ctx context.Context, image string) (err error) {
 
 	_, err = c.images.RemoveImage(ctx, request)
 	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil
+		}
 		return err
 	}
 
@@ -308,7 +313,7 @@ func removeImages(clientset *kubernetes.Clientset, c Client, socketPath string, 
 		}
 	}
 
-	if err := updateStatus(backgroundContext, clientset, results); err != nil {
+	if err := updateStatus(clientset, results); err != nil {
 		return err
 	}
 

--- a/pkg/eraser/eraser.go
+++ b/pkg/eraser/eraser.go
@@ -145,7 +145,11 @@ func getImageClient(ctx context.Context, socketPath string) (pb.ImageServiceClie
 	return imageClient, conn, nil
 }
 
-func updateStatus(ctx context.Context, clientset *kubernetes.Clientset, results []eraserv1alpha1.NodeCleanUpDetail) error {
+func updateStatus(clientset *kubernetes.Clientset, results []eraserv1alpha1.NodeCleanUpDetail) error {
+	// Use a fresh context here because we really want to make sure the context hasn't timed out already when we try to update the status
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
 	imageStatus := eraserv1alpha1.ImageStatus{
 		TypeMeta: v1.TypeMeta{
 			APIVersion: "eraser.sh/v1alpha1",

--- a/pkg/eraser/eraser.go
+++ b/pkg/eraser/eraser.go
@@ -31,8 +31,8 @@ const (
 )
 
 var (
-	// Timeout  of connecting to server (default: 10s).
-	timeout                  = 10 * time.Second
+	// Timeout  of connecting to server (default: 5m).
+	timeout                  = 5 * time.Minute
 	errProtocolNotSupported  = errors.New("protocol not supported")
 	errEndpointDeprecated    = errors.New("endpoint is deprecated, please consider using full url format")
 	errOnlySupportUnixSocket = errors.New("only support unix socket endpoint")

--- a/test/e2e/eraser_test.go
+++ b/test/e2e/eraser_test.go
@@ -5,7 +5,6 @@ package e2e
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -18,26 +17,18 @@ import (
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
-	"sigs.k8s.io/kind/pkg/cluster"
-)
-
-type Name string
-
-const depTest Name = "dep-test"
-
-var (
-	podSelectorLabels = map[string]string{"app": "nginx"}
 )
 
 func TestRemoveImagesFromAllNodes(t *testing.T) {
-	depFeat := features.New("Test Remove Images From All Nodes").
-		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+	const nginx = "nginx"
 
-			dep := newDeployment(cfg.Namespace(), "dep-test", 2, podSelectorLabels)
-			if err := cfg.Client().Resources().Create(ctx, dep); err != nil {
+	rmImageFeat := features.New("Test Remove Image From All Nodes").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			podSelectorLabels := map[string]string{"app": nginx}
+			nginxDep := newDeployment(cfg.Namespace(), nginx, 2, podSelectorLabels, corev1.Container{Image: nginx, Name: nginx})
+			if err := cfg.Client().Resources().Create(ctx, nginxDep); err != nil {
 				t.Error("Failed to create the dep", err)
 			}
-
 			return ctx
 		}).
 		Assess("deployment successfully deployed", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
@@ -47,7 +38,7 @@ func TestRemoveImagesFromAllNodes(t *testing.T) {
 			}
 
 			resultDeployment := appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{Name: "dep-test", Namespace: cfg.Namespace()},
+				ObjectMeta: metav1.ObjectMeta{Name: nginx, Namespace: cfg.Namespace()},
 			}
 
 			if err = wait.For(conditions.New(client.Resources()).DeploymentConditionMatch(&resultDeployment, appsv1.DeploymentAvailable, corev1.ConditionTrue),
@@ -55,40 +46,7 @@ func TestRemoveImagesFromAllNodes(t *testing.T) {
 				t.Error("deployment not found", err)
 			}
 
-			return context.WithValue(ctx, depTest, &resultDeployment)
-		}).
-		Assess("Pods successfully deployed to all nodes", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			// get Kind nodeList
-			provider := cluster.NewProvider(cluster.ProviderWithDocker())
-
-			nodeList, err := provider.ListNodes(kindClusterName)
-			if err != nil {
-				t.Error("Cannot list Kind node list", err)
-			}
-
-			// get podList
-			podList := &corev1.PodList{}
-			if err := cfg.Client().Resources(cfg.Namespace()).List(ctx, podList); err != nil {
-				t.Error("Cannot get pod list", err)
-			}
-
-			if len(podList.Items) == 0 {
-				t.Errorf("no pods in namespace %s", cfg.Namespace())
-			}
-
-			for _, node := range nodeList {
-				podFound := false
-				// make sure pod is running on each node
-				for _, pod := range podList.Items {
-					if (pod.Spec.NodeName == node.String() && !podFound) || strings.Contains(node.String(), "control-plane") {
-						podFound = true
-					}
-				}
-				if !podFound {
-					t.Errorf("pod is not running in the node %s", node.String())
-				}
-			}
-			return ctx
+			return context.WithValue(ctx, nginx, &resultDeployment)
 		}).
 		Assess("Images successfully deleted from all nodes", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			//delete deployment
@@ -96,7 +54,7 @@ func TestRemoveImagesFromAllNodes(t *testing.T) {
 			if err != nil {
 				t.Error("Failed to create new client", err)
 			}
-			dep := ctx.Value(depTest).(*appsv1.Deployment)
+			dep := ctx.Value(nginx).(*appsv1.Deployment)
 			if err := client.Resources().Delete(ctx, dep); err != nil {
 				t.Error("Failed to delete the dep", err)
 			}
@@ -106,55 +64,10 @@ func TestRemoveImagesFromAllNodes(t *testing.T) {
 				t.Error("Failed to deploy image list config", err)
 			}
 
-			//get image list and make sure the targeted image not there
+			ctxT, cancel := context.WithTimeout(ctx, time.Minute)
+			defer cancel()
+			checkImageRemoved(ctxT, t, getClusterNodes(t), nginx)
 
-			// get Kind nodeList
-			provider := cluster.NewProvider(cluster.ProviderWithDocker())
-
-			nodeList, err := provider.ListNodes(kindClusterName)
-			if err != nil {
-				t.Error("Cannot list Kind node list", err)
-			}
-			var ourNodes []string
-			for i := range nodeList {
-				n := nodeList[i].String()
-				if !strings.Contains(n, "control-plane") {
-					ourNodes = append(ourNodes, n)
-				}
-			}
-
-			timeout := time.NewTimer(time.Minute)
-			defer timeout.Stop()
-
-			cleaned := make(map[string]bool)
-
-			for len(cleaned) < len(ourNodes) {
-				select {
-				case <-timeout.C:
-					t.Error("timeout waiting for images to be cleaned")
-					break
-				default:
-				}
-				for _, node := range ourNodes {
-					done := cleaned[node]
-					if done {
-						continue
-					}
-
-					images, err := DockerExec(node)
-					if err != nil {
-						t.Error("Cannot list images", err)
-					}
-					if !strings.Contains(images, "nginx") {
-						cleaned[node] = true
-					}
-				}
-				time.Sleep(time.Second)
-			}
-
-			if len(cleaned) < len(ourNodes) {
-				t.Error("not all nodes cleaned")
-			}
 			return ctx
 		}).
 		Assess("Pods from imagejobs are cleaned up", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
@@ -190,5 +103,5 @@ func TestRemoveImagesFromAllNodes(t *testing.T) {
 			return ctx
 		}).Feature()
 
-	testenv.Test(t, depFeat)
+	testenv.Test(t, rmImageFeat)
 }

--- a/test/e2e/eraser_test.go
+++ b/test/e2e/eraser_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	eraserv1alpha1 "github.com/Azure/eraser/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,7 +21,13 @@ import (
 )
 
 func TestRemoveImagesFromAllNodes(t *testing.T) {
-	const nginx = "nginx"
+	const (
+		nginx = "nginx"
+		redis = "redis"
+		caddy = "caddy"
+
+		prune = "prune"
+	)
 
 	rmImageFeat := features.New("Test Remove Image From All Nodes").
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
@@ -100,8 +107,171 @@ func TestRemoveImagesFromAllNodes(t *testing.T) {
 			if err := KubectlDelete(cfg.KubeconfigFile(), "eraser-system", append([]string{"imagejob", "--all"})); err != nil {
 				t.Error("Failed to delete image job(s) config ", err)
 			}
+			if err := KubectlDelete(cfg.KubeconfigFile(), "eraser-system", append([]string{"imagestatus", "--all"})); err != nil {
+				t.Error("Failed to delete image job(s) config ", err)
+			}
+			if err := KubectlDelete(cfg.KubeconfigFile(), "eraser-system", append([]string{"imagelist", "--all"})); err != nil {
+				t.Error("Failed to delete image job(s) config ", err)
+			}
 			return ctx
 		}).Feature()
 
+	pruneImagesFeat := features.New("Remove all non-running images from cluster").
+		// Deploy 3 deployments with different images
+		// We'll shutdown two of them, run eraser with `*`, then check that the images for the removed deployments are removed from the cluster.
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			nginxDep := newDeployment(cfg.Namespace(), nginx, 2, map[string]string{"app": nginx}, corev1.Container{Image: nginx, Name: nginx})
+			if err := cfg.Client().Resources().Create(ctx, nginxDep); err != nil {
+				t.Error("Failed to create the nginx dep", err)
+			}
+
+			newDeployment(cfg.Namespace(), redis, 2, map[string]string{"app": redis}, corev1.Container{Image: redis, Name: redis})
+			err := cfg.Client().Resources().Create(ctx, newDeployment(cfg.Namespace(), redis, 2, map[string]string{"app": redis}, corev1.Container{Image: redis, Name: redis}))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			newDeployment(cfg.Namespace(), caddy, 2, map[string]string{"app": caddy}, corev1.Container{Image: caddy, Name: caddy})
+			if err := cfg.Client().Resources().Create(ctx, newDeployment(cfg.Namespace(), caddy, 2, map[string]string{"app": caddy}, corev1.Container{Image: caddy, Name: caddy})); err != nil {
+				t.Fatal(err)
+			}
+
+			return ctx
+		}).
+		Assess("Deployments successfully deployed", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Error("Failed to create new client", err)
+			}
+
+			nginxDep := appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: nginx, Namespace: cfg.Namespace()},
+			}
+
+			if err = wait.For(conditions.New(client.Resources()).DeploymentConditionMatch(&nginxDep, appsv1.DeploymentAvailable, corev1.ConditionTrue),
+				wait.WithTimeout(time.Minute*1)); err != nil {
+				t.Fatal("nginx deployment not found", err)
+			}
+			ctx = context.WithValue(ctx, nginx, &nginxDep)
+
+			redisDep := appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: redis, Namespace: cfg.Namespace()},
+			}
+			if err = wait.For(conditions.New(client.Resources()).DeploymentConditionMatch(&redisDep, appsv1.DeploymentAvailable, corev1.ConditionTrue),
+				wait.WithTimeout(time.Minute*1)); err != nil {
+				t.Fatal("redis deployment not found", err)
+			}
+			ctx = context.WithValue(ctx, redis, &redisDep)
+
+			caddyDep := appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: caddy, Namespace: cfg.Namespace()},
+			}
+			if err = wait.For(conditions.New(client.Resources()).DeploymentConditionMatch(&caddyDep, appsv1.DeploymentAvailable, corev1.ConditionTrue),
+				wait.WithTimeout(time.Minute*1)); err != nil {
+				t.Fatal("caddy deployment not found", err)
+			}
+			ctx = context.WithValue(ctx, caddy, &caddyDep)
+
+			return ctx
+		}).
+		Assess("Remove some of the deployments so the images aren't running", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			// Here we remove the redis and caddy deployments
+			// Keep nginx running and ensure nginx is not deleted.
+			var redisPods corev1.PodList
+			if err := cfg.Client().Resources().List(ctx, &redisPods, func(o *metav1.ListOptions) {
+				o.LabelSelector = labels.SelectorFromSet(map[string]string{"app": redis}).String()
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if len(redisPods.Items) != 2 {
+				t.Fatal("missing pods in redis deployment")
+			}
+
+			var caddyPods corev1.PodList
+			if err := cfg.Client().Resources().List(ctx, &caddyPods, func(o *metav1.ListOptions) {
+				o.LabelSelector = labels.SelectorFromSet(map[string]string{"app": caddy}).String()
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if len(caddyPods.Items) != 2 {
+				t.Fatal("missing pods in caddy deployment")
+			}
+
+			err := cfg.Client().Resources().Delete(ctx, ctx.Value(redis).(*appsv1.Deployment))
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = cfg.Client().Resources().Delete(ctx, ctx.Value(caddy).(*appsv1.Deployment))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = wait.For(conditions.New(cfg.Client().Resources()).ResourcesDeleted(&redisPods), wait.WithTimeout(time.Minute*1))
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = wait.For(conditions.New(cfg.Client().Resources()).ResourcesDeleted(&caddyPods), wait.WithTimeout(time.Minute*1))
+			if err != nil {
+				t.Fatal(err)
+			}
+			return ctx
+		}).
+		Assess("All non-running images are removed from the cluster", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			imgList := &eraserv1alpha1.ImageList{
+				ObjectMeta: metav1.ObjectMeta{Name: prune},
+				Spec: eraserv1alpha1.ImageListSpec{
+					Images: []string{"*"},
+				},
+			}
+
+			if err := cfg.Client().Resources().Create(ctx, imgList); err != nil {
+				t.Fatal(err)
+			}
+			ctx = context.WithValue(ctx, prune, imgList)
+
+			// The first check could take some extra time, where as things should be done already for the 2nd check.
+			// So we'll give plenty of time and fail slow here.
+			ctxT, cancel := context.WithTimeout(ctx, 5*time.Minute)
+			defer cancel()
+			checkImageRemoved(ctxT, t, getClusterNodes(t), redis)
+
+			ctxT, cancel = context.WithTimeout(ctx, time.Minute)
+			defer cancel()
+			checkImageRemoved(ctxT, t, getClusterNodes(t), caddy)
+
+			// Make sure nginx is still there
+			checkImagesExist(ctx, t, getClusterNodes(t), nginx)
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			if i := ctx.Value(nginx); i != nil {
+				cfg.Client().Resources().Delete(ctx, i.(*appsv1.Deployment))
+			}
+			if i := ctx.Value(redis); i != nil {
+				cfg.Client().Resources().Delete(ctx, i.(*appsv1.Deployment))
+			}
+			if i := ctx.Value(caddy); i != nil {
+				cfg.Client().Resources().Delete(ctx, i.(*appsv1.Deployment))
+			}
+			if i := ctx.Value(prune); i != nil {
+				cfg.Client().Resources().Delete(ctx, i.(*eraserv1alpha1.ImageList))
+			}
+
+			if err := KubectlDelete(cfg.KubeconfigFile(), "eraser-system", append([]string{"imagejob", "--all"})); err != nil {
+				t.Error("Failed to delete image job(s) config ", err)
+			}
+			if err := KubectlDelete(cfg.KubeconfigFile(), "eraser-system", append([]string{"imagestatus", "--all"})); err != nil {
+				t.Error("Failed to delete image job(s) config ", err)
+			}
+			if err := KubectlDelete(cfg.KubeconfigFile(), "eraser-system", append([]string{"imagelist", "--all"})); err != nil {
+				t.Error("Failed to delete image job(s) config ", err)
+			}
+
+			return ctx
+		}).
+		Feature()
+
 	testenv.Test(t, rmImageFeat)
+	testenv.Test(t, pruneImagesFeat)
 }

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -11,9 +11,12 @@ import (
 	"testing"
 	"time"
 
+	eraserv1alpha1 "github.com/Azure/eraser/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/e2e-framework/klient/wait"
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
@@ -34,6 +37,8 @@ var (
 )
 
 func TestMain(m *testing.M) {
+	utilruntime.Must(eraserv1alpha1.AddToScheme(scheme.Scheme))
+
 	testenv = env.NewWithConfig(envconf.New())
 	// Create KinD Cluster
 	namespace := envconf.RandomName("eraser-ns", 16)

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -130,6 +130,25 @@ func getClusterNodes(t *testing.T) []string {
 	return ourNodes
 }
 
+func checkImagesExist(ctx context.Context, t *testing.T, nodes []string, images ...string) {
+	t.Helper()
+
+	for _, node := range nodes {
+		nodeImages, err := listNodeImages(node)
+		if err != nil {
+			t.Errorf("Cannot list images on node %s: %v", node, err)
+			continue
+		}
+
+		for _, image := range images {
+			if !strings.Contains(nodeImages, image) {
+				t.Errorf("image %s missing on node %s", image, node)
+			}
+		}
+
+	}
+}
+
 func checkImageRemoved(ctx context.Context, t *testing.T, nodes []string, images ...string) {
 	t.Helper()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

A few cleanup things, but mainly it adds support for pruning all non-running images.
This is done by specifying `*` in an imagelist.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
