### PR TITLE
Do not require cluster access for eraser pod

### DIFF
--- a/api/v1alpha1/imagejob_types.go
+++ b/api/v1alpha1/imagejob_types.go
@@ -27,8 +27,7 @@ import (
 // ImageJobSpec defines the desired state of ImageJob.
 type ImageJobSpec struct {
 	// Specifies the job that will be created when executing an ImageJob.
-	JobTemplate   v1.PodTemplateSpec `json:"template"`
-	ImageListName string             `json:"imageListName"`
+	JobTemplate v1.PodTemplateSpec `json:"template"`
 }
 
 // JobPhase defines the phase of an ImageJob status.

--- a/config/crd/bases/eraser.sh_imagejobs.yaml
+++ b/config/crd/bases/eraser.sh_imagejobs.yaml
@@ -32,8 +32,6 @@ spec:
           spec:
             description: ImageJobSpec defines the desired state of ImageJob.
             properties:
-              imageListName:
-                type: string
               template:
                 description: Specifies the job that will be created when executing an ImageJob.
                 properties:
@@ -3957,7 +3955,6 @@ spec:
                     type: object
                 type: object
             required:
-            - imageListName
             - template
             type: object
           status:

--- a/controllers/imagelist/imagelist_controller.go
+++ b/controllers/imagelist/imagelist_controller.go
@@ -97,6 +97,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		job := &eraserv1alpha1.ImageJob{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "imagejob-",
+				OwnerReferences: []metav1.OwnerReference{
+					*metav1.NewControllerRef(imageList, imageList.GroupVersionKind()),
+				},
 			},
 			Spec: eraserv1alpha1.ImageJobSpec{
 				JobTemplate: corev1.PodTemplateSpec{
@@ -107,13 +110,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 								Name:            "eraser",
 								Image:           *eraserImage,
 								ImagePullPolicy: corev1.PullIfNotPresent,
-								Args:            []string{"--imagelist=" + req.Name},
 							},
 						},
-						ServiceAccountName: "eraser-controller-manager",
 					},
 				},
-				ImageListName: req.Name,
 			},
 		}
 		err := r.Create(ctx, job)

--- a/manifest_staging/deploy/eraser.yaml
+++ b/manifest_staging/deploy/eraser.yaml
@@ -37,8 +37,6 @@ spec:
           spec:
             description: ImageJobSpec defines the desired state of ImageJob.
             properties:
-              imageListName:
-                type: string
               template:
                 description: Specifies the job that will be created when executing an ImageJob.
                 properties:
@@ -3962,7 +3960,6 @@ spec:
                     type: object
                 type: object
             required:
-            - imageListName
             - template
             type: object
           status:


### PR DESCRIPTION
Makes eraser read the imagelist from a configmap.
This does a few things:

1. No longer need cluster access
2. Provides an immutable list of images that every eraser pod uses for a
   given job.
3. Reduces requests on the cluster

One downside of this is we store the list multiple times (in the
imagelist and a configmap for each job run).

Closes #114