### PR TITLE
increase e2e timeout to 20min

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,7 +73,7 @@ jobs:
   e2e-test:
     name: "E2E test"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3


### PR DESCRIPTION
**What this PR does / why we need it**:
Increases e2e timeout to 20min. After adding a test for imagelist-reconcile-on-update, we need more time to run all three tests.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
