### PR TITLE
Stabilize e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ GO_INSTALL := ./hack/go-install.sh
 GOLANGCI_LINT_BIN := golangci-lint
 GOLANGCI_LINT := $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN)-v$(GOLANGCI_LINT_VERSION)
 
+TEST_COUNT ?= 1
+
 $(GOLANGCI_LINT):
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) github.com/golangci/golangci-lint/cmd/golangci-lint $(GOLANGCI_LINT_BIN) v$(GOLANGCI_LINT_VERSION)
 
@@ -98,7 +100,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 # Run e2e tests
 .PHONY: e2e-test
 e2e-test:
-	IMAGE=${ERASER_IMG} MANAGER_IMAGE=${MANAGER_IMG} NODE_VERSION=kindest/node:v${KUBERNETES_VERSION} go test -count=1 -tags=e2e -v ./test/e2e
+	CGO_ENABLED=0 IMAGE=${ERASER_IMG} MANAGER_IMAGE=${MANAGER_IMG} NODE_VERSION=kindest/node:v${KUBERNETES_VERSION} go test -count=$(TEST_COUNT) -timeout 1200s -tags=e2e -v ./test/e2e
 
 ##@ Build
 

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -75,6 +75,17 @@ func deployEraserConfig(kubeConfig, namespace, resourcePath, fileName string) er
 	return nil
 }
 
+func containerNotPresentOnNode(nodeName, containerName string) func() (bool, error) {
+	return func() (bool, error) {
+		output, err := listNodeContainers(nodeName)
+		if err != nil {
+			return false, err
+		}
+
+		return !strings.Contains(output, containerName), nil
+	}
+}
+
 // delete eraser config
 func deleteEraserConfig(kubeConfig, namespace, resourcePath, fileName string) error {
 	wd, err := os.Getwd()
@@ -92,6 +103,22 @@ func deleteEraserConfig(kubeConfig, namespace, resourcePath, fileName string) er
 	}
 
 	return nil
+}
+
+func listNodeContainers(nodeName string) (string, error) {
+	args := []string{
+		"exec",
+		nodeName,
+		"ctr",
+		"-n",
+		"k8s.io",
+		"containers",
+		"list",
+	}
+
+	cmd := exec.Command("docker", args...)
+	stdoutStderr, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(stdoutStderr)), err
 }
 
 func listNodeImages(nodeName string) (string, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Resolves #134

There is a lag between when a) the kubernetes client recognizes a
resource (representing a container or containers) has been deleted, and
b) containerd recognizes the containers as stopped or non-running.

Instead of polling the kubernetes api server, poll containerd directly
using `ctr` on the kind nodes. Once the container is stopped, we may
proceed with the eraser deployment.


**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #134 

**Special notes for your reviewer**:
#141 will be rebased on top of this one