### PR TITLE
Update to support multi-arch builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
 # syntax=mcr.microsoft.com/oss/moby/dockerfile:1.3.1
-ARG BUILDPLATFORM="linux/amd64"
 ARG BUILDERIMAGE="golang:1.17"
 
 ARG ERASERBASEIMAGE="gcr.io/distroless/static:latest"
 ARG MANAGERBASEIMAGE="gcr.io/distroless/static:nonroot"
 
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 
 # Build the manager binary
 FROM --platform=$BUILDPLATFORM $BUILDERIMAGE AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@ ARG BUILDERIMAGE="golang:1.17"
 ARG ERASERBASEIMAGE="gcr.io/distroless/static:latest"
 ARG MANAGERBASEIMAGE="gcr.io/distroless/static:nonroot"
 
-ARG TARGETOS
-ARG TARGETARCH
-
 # Build the manager binary
 FROM --platform=$BUILDPLATFORM $BUILDERIMAGE AS builder
 WORKDIR /workspace
@@ -24,12 +21,20 @@ RUN \
 COPY . .
 
 FROM builder AS manager-build
+
+ARG TARGETOS
+ARG TARGETARCH
+
 RUN \
     --mount=type=cache,target=${GOCACHE} \
     --mount=type=cache,target=/go/pkg/mod \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o out/manager main.go
 
 FROM builder AS eraser-build
+
+ARG TARGETOS
+ARG TARGETARCH
+
 RUN \
     --mount=type=cache,target=${GOCACHE} \
     --mount=type=cache,target=/go/pkg/mod \

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ KUBERNETES_VERSION ?= 1.23.0
 ENVTEST_K8S_VERSION ?= 1.23
 GOLANGCI_LINT_VERSION := 1.43.0
 
-PLATFORM ?= linux/amd64
+PLATFORM ?= linux
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ KUBERNETES_VERSION ?= 1.23.0
 ENVTEST_K8S_VERSION ?= 1.23
 GOLANGCI_LINT_VERSION := 1.43.0
 
+PLATFORMS ?= linux/amd64
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -111,13 +113,13 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 docker-build-manager: ## Build docker image with the manager.
-	docker buildx build $(_CACHE_FROM) $(_CACHE_TO) --platform="linux/amd64" --output=$(OUTPUT_TYPE) --target manager -t ${MANAGER_IMG} .
+	docker buildx build $(_CACHE_FROM) $(_CACHE_TO) --platform="$(PLATFORMS)" --output=$(OUTPUT_TYPE) --target manager -t ${MANAGER_IMG} .
 
 docker-push-manager: ## Push docker image with the manager.
 	docker push ${MANAGER_IMG}
 
 docker-build-eraser:
-	docker buildx build $(_CACHE_FROM) $(_CACHE_TO) --platform="linux/amd64" --output=$(OUTPUT_TYPE) -t ${ERASER_IMG} --target eraser .
+	docker buildx build $(_CACHE_FROM) $(_CACHE_TO) --platform="$(PLATFORMS)" --output=$(OUTPUT_TYPE) -t ${ERASER_IMG} --target eraser .
 
 docker-push-eraser:
 	docker push ${ERASER_IMG}

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ KUBERNETES_VERSION ?= 1.23.0
 ENVTEST_K8S_VERSION ?= 1.23
 GOLANGCI_LINT_VERSION := 1.43.0
 
-PLATFORMS ?= linux/amd64
+PLATFORM ?= linux/amd64
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -113,13 +113,13 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 docker-build-manager: ## Build docker image with the manager.
-	docker buildx build $(_CACHE_FROM) $(_CACHE_TO) --platform="$(PLATFORMS)" --output=$(OUTPUT_TYPE) --target manager -t ${MANAGER_IMG} .
+	docker buildx build $(_CACHE_FROM) $(_CACHE_TO) --platform="$(PLATFORM)" --output=$(OUTPUT_TYPE) --target manager -t ${MANAGER_IMG} .
 
 docker-push-manager: ## Push docker image with the manager.
 	docker push ${MANAGER_IMG}
 
 docker-build-eraser:
-	docker buildx build $(_CACHE_FROM) $(_CACHE_TO) --platform="$(PLATFORMS)" --output=$(OUTPUT_TYPE) -t ${ERASER_IMG} --target eraser .
+	docker buildx build $(_CACHE_FROM) $(_CACHE_TO) --platform="$(PLATFORM)" --output=$(OUTPUT_TYPE) -t ${ERASER_IMG} --target eraser .
 
 docker-push-eraser:
 	docker push ${ERASER_IMG}


### PR DESCRIPTION
Signed-off-by: Jeremy Rickard <jrickard@microsoft.com>

**What this PR does / why we need it**:

This PR updates the Dockerfile/Makefile to support building arm64 in addition to amd64. 

Highlights:

* Update Dockerfile  to use the TARGETOS and TARGETARCH arguments passed by build kit in order to properly compile for the selected platform (i.e. linux/arm64 or linux/amd64). 
* Updates the FROM statements to use --platform and moves the base images to arguments as well. 
* Updates Makefile to move platform to a variable to allow users to override when using the make targets

This doesn't update the Makefile to produce linux/arm64 containers as part of a release process but might be good to do that in a follow up? 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #151 

**Special notes for your reviewer**:
