### PR TITLE
Fix alias bug

### DIFF
--- a/pkg/eraser/eraser.go
+++ b/pkg/eraser/eraser.go
@@ -145,17 +145,6 @@ func getImageClient(ctx context.Context, socketPath string) (pb.ImageServiceClie
 	return imageClient, conn, nil
 }
 
-func mapContainsValue(idMap map[string][]string, img string) bool {
-	for _, v := range idMap {
-		if len(v) > 0 {
-			if v[0] == img {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 func removeImages(c Client, targetImages []string) error {
 	backgroundContext, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()

--- a/pkg/eraser/eraser.go
+++ b/pkg/eraser/eraser.go
@@ -177,10 +177,8 @@ func removeImages(c Client, targetImages []string) error {
 		digest := curr.GetImage()
 		runningImages[digest] = digest
 
-		if idToTagListMap[digest] != nil {
-			for _, tag := range idToTagListMap[digest] {
-				runningImages[tag] = digest
-			}
+		for _, tag := range idToTagListMap[digest] {
+			runningImages[tag] = digest
 		}
 	}
 
@@ -191,10 +189,8 @@ func removeImages(c Client, targetImages []string) error {
 		if _, isRunning := runningImages[digest]; !isRunning {
 			nonRunningImages[digest] = digest
 
-			if idToTagListMap[digest] != nil {
-				for _, tag := range idToTagListMap[digest] {
-					nonRunningImages[tag] = digest
-				}
+			for _, tag := range idToTagListMap[digest] {
+				nonRunningImages[tag] = digest
 			}
 		}
 	}

--- a/pkg/eraser/eraser.go
+++ b/pkg/eraser/eraser.go
@@ -209,8 +209,7 @@ func removeImages(c Client, targetImages []string) error {
 			continue
 		}
 
-		digest, isNonRunning := nonRunningImages[imgDigestOrTag]
-		if isNonRunning {
+		if digest, isNonRunning := nonRunningImages[imgDigestOrTag]; isNonRunning {
 			err = c.deleteImage(backgroundContext, digest)
 			if err != nil {
 				log.Error(err, "Error removing", "image", digest)

--- a/test/e2e/eraser_test.go
+++ b/test/e2e/eraser_test.go
@@ -22,9 +22,12 @@ import (
 
 func TestRemoveImagesFromAllNodes(t *testing.T) {
 	const (
-		nginx = "nginx"
-		redis = "redis"
-		caddy = "caddy"
+		nginx         = "nginx"
+		nginxLatest   = "docker.io/library/nginx:latest"
+		nginxAliasOne = "docker.io/library/nginx:one"
+		nginxAliasTwo = "docker.io/library/nginx:two"
+		redis         = "redis"
+		caddy         = "caddy"
 
 		prune = "imagelist"
 	)

--- a/test/e2e/eraser_test.go
+++ b/test/e2e/eraser_test.go
@@ -502,7 +502,7 @@ func TestRemoveImagesFromAllNodes(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "nginxone", Namespace: cfg.Namespace()},
 			}
 
-			err = wait.For(conditions.New(client.Resources()).PodConditionMatch(&resultPod, corev1.PodReady, corev1.ConditionTrue), wait.WithTimeout(time.Minute*1))
+			err = wait.For(conditions.New(client.Resources()).PodConditionMatch(&resultPod, corev1.PodReady, corev1.ConditionTrue), wait.WithTimeout(time.Minute*3))
 			if err != nil {
 				t.Error("pod not deployed", err)
 			}
@@ -511,7 +511,7 @@ func TestRemoveImagesFromAllNodes(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "nginxtwo", Namespace: cfg.Namespace()},
 			}
 
-			err = wait.For(conditions.New(client.Resources()).PodConditionMatch(&resultPod, corev1.PodReady, corev1.ConditionTrue), wait.WithTimeout(time.Minute*1))
+			err = wait.For(conditions.New(client.Resources()).PodConditionMatch(&resultPod, corev1.PodReady, corev1.ConditionTrue), wait.WithTimeout(time.Minute*3))
 			if err != nil {
 				t.Error("pod not deployed", err)
 			}

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -83,7 +83,12 @@ func kubectl(args []string) (string, error) {
 	klog.Infof("kubectl %s", strings.Join(args, " "))
 
 	cmd := exec.Command("kubectl", args...)
-	stdoutStderr, err := cmd.CombinedOutput()
 
-	return strings.TrimSpace(string(stdoutStderr)), err
+	stdoutStderr, err := cmd.CombinedOutput()
+	output := strings.TrimSpace(string(stdoutStderr))
+	if err != nil {
+		err = fmt.Errorf("%w: %s", err, output)
+	}
+
+	return output, err
 }

--- a/test/e2e/test-data/eraser_v1alpha1_imagelist_alias.yaml
+++ b/test/e2e/test-data/eraser_v1alpha1_imagelist_alias.yaml
@@ -1,7 +1,0 @@
-apiVersion: eraser.sh/v1alpha1
-kind: ImageList
-metadata:
-  name: imagelist
-spec:
-  images:
-    - docker.io/library/nginx:two

--- a/test/e2e/test-data/eraser_v1alpha1_imagelist_alias.yaml
+++ b/test/e2e/test-data/eraser_v1alpha1_imagelist_alias.yaml
@@ -4,6 +4,4 @@ metadata:
   name: imagelist
 spec:
   images:
-    - sha256:2834dc507516af02784808c5f48b7cbe38b8ed5d0f4837f16e78d00deb7e7767
-    - docker.io/library/nginx:latest
-    - nginx:two
+    - docker.io/library/nginx:two

--- a/test/e2e/test-data/eraser_v1alpha1_imagelist_alias.yaml
+++ b/test/e2e/test-data/eraser_v1alpha1_imagelist_alias.yaml
@@ -1,0 +1,9 @@
+apiVersion: eraser.sh/v1alpha1
+kind: ImageList
+metadata:
+  name: imagelist
+spec:
+  images:
+    - sha256:2834dc507516af02784808c5f48b7cbe38b8ed5d0f4837f16e78d00deb7e7767
+    - docker.io/library/nginx:latest
+    - nginx:two

--- a/test/e2e/test-data/eraser_v1alpha1_imagelist_updated.yaml
+++ b/test/e2e/test-data/eraser_v1alpha1_imagelist_updated.yaml
@@ -5,4 +5,3 @@ metadata:
 spec:
   images:
     - "*"
-    

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -5,6 +5,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -136,7 +137,12 @@ func listNodeContainers(nodeName string) (string, error) {
 
 	cmd := exec.Command("docker", args...)
 	stdoutStderr, err := cmd.CombinedOutput()
-	return strings.TrimSpace(string(stdoutStderr)), err
+	output := strings.TrimSpace(string(stdoutStderr))
+	if err != nil {
+		err = fmt.Errorf("%w: %s", err, output)
+	}
+
+	return output, err
 }
 
 func listNodeImages(nodeName string) (string, error) {
@@ -152,7 +158,12 @@ func listNodeImages(nodeName string) (string, error) {
 
 	cmd := exec.Command("docker", args...)
 	stdoutStderr, err := cmd.CombinedOutput()
-	return strings.TrimSpace(string(stdoutStderr)), err
+	output := strings.TrimSpace(string(stdoutStderr))
+	if err != nil {
+		err = fmt.Errorf("%w: %s", err, output)
+	}
+
+	return output, err
 }
 
 // This lists nodes in the cluster, filtering out the control-plane
@@ -238,20 +249,38 @@ func checkImageRemoved(ctx context.Context, t *testing.T, nodes []string, images
 func dockerPullImage(image string) (string, error) {
 	args := []string{"pull", image}
 	cmd := exec.Command("docker", args...)
+
 	stdoutStderr, err := cmd.CombinedOutput()
-	return strings.TrimSpace(string(stdoutStderr)), err
+	output := strings.TrimSpace(string(stdoutStderr))
+	if err != nil {
+		err = fmt.Errorf("%w: %s", err, output)
+	}
+
+	return output, err
 }
 
 func dockerTagImage(image, tag string) (string, error) {
 	args := []string{"tag", image, tag}
 	cmd := exec.Command("docker", args...)
+
 	stdoutStderr, err := cmd.CombinedOutput()
-	return strings.TrimSpace(string(stdoutStderr)), err
+	output := strings.TrimSpace(string(stdoutStderr))
+	if err != nil {
+		err = fmt.Errorf("%w: %s", err, output)
+	}
+
+	return output, err
 }
 
 func kindLoadImage(clusterName, image string) (string, error) {
 	args := []string{"load", "docker-image", image, "--name", clusterName}
 	cmd := exec.Command("kind", args...)
+
 	stdoutStderr, err := cmd.CombinedOutput()
-	return strings.TrimSpace(string(stdoutStderr)), err
+	output := strings.TrimSpace(string(stdoutStderr))
+	if err != nil {
+		err = fmt.Errorf("%w: %s", err, output)
+	}
+
+	return output, err
 }

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -56,6 +56,24 @@ func newDeployment(namespace, name string, replicas int32, labels map[string]str
 	}
 }
 
+func newPod(namespace, image, name, nodeName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+			Containers: []corev1.Container{
+				{
+					Name:  name,
+					Image: image,
+				},
+			},
+		},
+	}
+}
+
 // deploy eraser config
 func deployEraserConfig(kubeConfig, namespace, resourcePath, fileName string) error {
 	wd, err := os.Getwd()
@@ -215,4 +233,25 @@ func checkImageRemoved(ctx context.Context, t *testing.T, nodes []string, images
 	if len(cleaned) < len(nodes) {
 		t.Error("not all nodes cleaned")
 	}
+}
+
+func dockerPullImage(image string) (string, error) {
+	args := []string{"pull", image}
+	cmd := exec.Command("docker", args...)
+	stdoutStderr, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(stdoutStderr)), err
+}
+
+func dockerTagImage(image, tag string) (string, error) {
+	args := []string{"tag", image, tag}
+	cmd := exec.Command("docker", args...)
+	stdoutStderr, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(stdoutStderr)), err
+}
+
+func kindLoadImage(clusterName, image string) (string, error) {
+	args := []string{"load", "docker-image", image, "--name", clusterName}
+	cmd := exec.Command("kind", args...)
+	stdoutStderr, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(stdoutStderr)), err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
* Fixes a bug whereby images supplied in the imagelist were not being removed. This would happen consistently when one image was referred to by multiple names.  For a more thorough description of the bug, see #130 .
* Streamlines the removal logic, so that we can always delete by digest. Even when a name is provided, it is first mapped to a digest, then removed by digest.
* Adds an e2e test to prevent regression.
* A solid effort at tidying and refactoring in `eraser.go`.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #130 

**Special notes for your reviewer**:
