### PR TITLE
Add generic TESTFLAGS for passing flags to go test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ GOLANGCI_LINT_BIN := golangci-lint
 GOLANGCI_LINT := $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN)-v$(GOLANGCI_LINT_VERSION)
 
 TEST_COUNT ?= 1
+TIMEOUT ?= 1200s
 
 $(GOLANGCI_LINT):
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) github.com/golangci/golangci-lint/cmd/golangci-lint $(GOLANGCI_LINT_BIN) v$(GOLANGCI_LINT_VERSION)
@@ -102,7 +103,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 # Run e2e tests
 .PHONY: e2e-test
 e2e-test:
-	CGO_ENABLED=0 IMAGE=${ERASER_IMG} MANAGER_IMAGE=${MANAGER_IMG} NODE_VERSION=kindest/node:v${KUBERNETES_VERSION} go test -count=$(TEST_COUNT) -timeout 1200s -tags=e2e -v ./test/e2e
+	CGO_ENABLED=0 IMAGE=${ERASER_IMG} MANAGER_IMAGE=${MANAGER_IMG} NODE_VERSION=kindest/node:v${KUBERNETES_VERSION} go test -count=$(TEST_COUNT) -timeout=$(TIMEOUT) $(TESTFLAGS) -tags=e2e -v ./test/e2e
 
 ##@ Build
 


### PR DESCRIPTION
This lets us be able to do things like run a single e2e test.
Example: `make e2e-test TESTFLAGS="-run <regex>"`