### PR TITLE
Only delay deltion when until is sufficiently long

### DIFF
--- a/controllers/imagejob/imagejob_controller.go
+++ b/controllers/imagejob/imagejob_controller.go
@@ -177,9 +177,10 @@ func (r *Reconciler) handleCompletedJob(ctx context.Context, j *eraserv1alpha1.I
 		return ctrl.Result{}, nil
 	}
 
-	if !metav1.Now().After(j.Status.DeleteAfter.Time) {
+	until := time.Until(j.Status.DeleteAfter.Time)
+	if until > 0 {
 		log.Info("Delaying imagejob delete", "job", j.Name, "deleteAter", j.Status.DeleteAfter)
-		return ctrl.Result{RequeueAfter: time.Until(j.Status.DeleteAfter.Time)}, nil
+		return ctrl.Result{RequeueAfter: until}, nil
 	}
 
 	log.Info("Deleting imagejob", "job", j.Name)


### PR DESCRIPTION
Found a case where requeue wasn't actually occurring because
`RequeueAfter` was being set to 0 because we recalculated the delay
after we checked it (and calculated it slightly differently).
This casued deletion to never happen since `RequeueAfter` must be > 0 to
actually trigger a requeue..