### PR TITLE
Remove unnecessary mkdir in eraser-tooling

### DIFF
--- a/build/tooling/Dockerfile
+++ b/build/tooling/Dockerfile
@@ -2,5 +2,4 @@ FROM golang:1.17
 
 RUN GO111MODULE=on go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.5.0
 
-RUN mkdir /eraser
 WORKDIR /eraser


### PR DESCRIPTION
**What this PR does / why we need it**:

Cleaning the Dockerfile for eraser-tooling. `WORKDIR` command already creates that dir (see [reference](https://docs.docker.com/engine/reference/builder/#workdir)).

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
