### PR TITLE
Move imagejob deletion to imagelist controller

### DIFF
--- a/controllers/consts/constants.go
+++ b/controllers/consts/constants.go
@@ -1,5 +1,0 @@
-package consts
-
-const (
-	ImageJobOwnerLabelKey = "eraser.sh/imagejob.owner"
-)

--- a/controllers/consts/constants.go
+++ b/controllers/consts/constants.go
@@ -1,0 +1,5 @@
+package consts
+
+const (
+	ImageJobOwnerLabelKey = "eraser.sh/imagejob.owner"
+)

--- a/controllers/imagejob/imagejob_controller.go
+++ b/controllers/imagejob/imagejob_controller.go
@@ -111,9 +111,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Watch for changes to ImageJob
 	err = c.Watch(&source.Kind{Type: &eraserv1alpha1.ImageJob{}}, &handler.EnqueueRequestForObject{}, predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			if job, ok := e.ObjectNew.(*eraserv1alpha1.ImageJob); ok &&
-				job.Status.Phase == eraserv1alpha1.PhaseCompleted ||
-				job.Status.Phase == eraserv1alpha1.PhaseFailed {
+			if job, ok := e.ObjectNew.(*eraserv1alpha1.ImageJob); ok && util.IsCompletedOrFailed(job.Status.Phase) {
 				return false // handled by Owning controller
 			}
 

--- a/controllers/imagejob/imagejob_controller.go
+++ b/controllers/imagejob/imagejob_controller.go
@@ -36,13 +36,16 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	eraserv1alpha1 "github.com/Azure/eraser/api/v1alpha1"
+	"github.com/Azure/eraser/controllers/util"
 	"github.com/Azure/eraser/pkg/logger"
 )
 
@@ -106,7 +109,20 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to ImageJob
-	err = c.Watch(&source.Kind{Type: &eraserv1alpha1.ImageJob{}}, &handler.EnqueueRequestForObject{})
+	err = c.Watch(&source.Kind{Type: &eraserv1alpha1.ImageJob{}}, &handler.EnqueueRequestForObject{}, predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if job, ok := e.ObjectNew.(*eraserv1alpha1.ImageJob); ok &&
+				job.Status.Phase == eraserv1alpha1.PhaseCompleted ||
+				job.Status.Phase == eraserv1alpha1.PhaseFailed {
+				return false // handled by Owning controller
+			}
+
+			return true
+		},
+		CreateFunc:  util.AlwaysOnCreate,
+		GenericFunc: util.NeverOnGeneric,
+		DeleteFunc:  util.NeverOnDelete,
+	})
 	if err != nil {
 		return err
 	}
@@ -173,27 +189,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return ctrl.Result{}, fmt.Errorf("reconcile running: %w", err)
 		}
 	case eraserv1alpha1.PhaseCompleted, eraserv1alpha1.PhaseFailed:
-		return r.handleCompletedJob(ctx, imageJob)
+		break // this is handled by the Owning controller
 	default:
 		return ctrl.Result{}, fmt.Errorf("reconcile: unexpected imagejob phase: %s", imageJob.Status.Phase)
 	}
 
 	return ctrl.Result{}, nil
-}
-
-func (r *Reconciler) handleCompletedJob(ctx context.Context, j *eraserv1alpha1.ImageJob) (ctrl.Result, error) {
-	if j.Status.DeleteAfter == nil {
-		return ctrl.Result{}, nil
-	}
-
-	until := time.Until(j.Status.DeleteAfter.Time)
-	if until > 0 {
-		log.Info("Delaying imagejob delete", "job", j.Name, "deleteAter", j.Status.DeleteAfter)
-		return ctrl.Result{RequeueAfter: until}, nil
-	}
-
-	log.Info("Deleting imagejob", "job", j.Name)
-	return ctrl.Result{}, r.Delete(ctx, j)
 }
 
 func podListOptions(j *eraserv1alpha1.ImageJob) client.ListOptions {
@@ -250,19 +251,7 @@ func (r *Reconciler) handleRunningJob(ctx context.Context, imageJob *eraserv1alp
 		return err
 	}
 
-	imageList := &eraserv1alpha1.ImageList{}
-	err = r.Get(ctx, types.NamespacedName{Name: imageJob.OwnerReferences[0].Name}, imageList)
-	if err != nil {
-		return err
-	}
-
-	now := metav1.Now()
-	imageList.Status.Timestamp = &now
-	imageList.Status.Skipped = int64(skipped)
-	imageList.Status.Success = int64(success)
-	imageList.Status.Failed = int64(failed)
-
-	return r.Status().Update(ctx, imageList)
+	return nil
 }
 
 func after(t time.Time, seconds int64) *metav1.Time {

--- a/controllers/imagejob/imagejob_controller.go
+++ b/controllers/imagejob/imagejob_controller.go
@@ -321,11 +321,6 @@ func (r *Reconciler) handleNewJob(ctx context.Context, imageJob *eraserv1alpha1.
 		log.Info("Started eraser pod on node", "nodeName", nodeName)
 	}
 
-	imageJob.Status.Skipped = skipped
-	if err := r.updateJobStatus(ctx, imageJob); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/controllers/imagelist/imagelist_controller.go
+++ b/controllers/imagelist/imagelist_controller.go
@@ -103,7 +103,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	items := util.FilterJobListByOwner(jobList.Items, *metav1.NewControllerRef(&imageList, imageList.GroupVersionKind()))
+	items := util.FilterJobListByOwner(jobList.Items, metav1.NewControllerRef(&imageList, imageList.GroupVersionKind()))
 
 	switch len(items) {
 	case 0:

--- a/controllers/imagelist/imagelist_controller.go
+++ b/controllers/imagelist/imagelist_controller.go
@@ -36,7 +36,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	eraserv1alpha1 "github.com/Azure/eraser/api/v1alpha1"
-	"github.com/Azure/eraser/controllers/consts"
 	"github.com/Azure/eraser/controllers/util"
 )
 
@@ -145,7 +144,6 @@ func (r *Reconciler) handleImageListEvent(ctx context.Context, req *ctrl.Request
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(imageList, imageList.GroupVersionKind()),
 			},
-			Labels: map[string]string{consts.ImageJobOwnerLabelKey: imageList.Name},
 		},
 		Spec: eraserv1alpha1.ImageJobSpec{
 			JobTemplate: corev1.PodTemplateSpec{

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -51,7 +51,7 @@ func FilterJobListByOwner(jobs []eraserv1alpha1.ImageJob, owner *metav1.OwnerRef
 		for j := range job.OwnerReferences {
 			or := job.OwnerReferences[j]
 
-			if or.UID == job.GetUID() {
+			if or.UID == owner.UID {
 				ret = append(ret, job)
 				break // inner
 			}

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	eraserv1alpha1 "github.com/Azure/eraser/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
@@ -39,4 +40,23 @@ func AlwaysOnUpdate(_ event.UpdateEvent) bool {
 
 func IsCompletedOrFailed(p eraserv1alpha1.JobPhase) bool {
 	return (p == eraserv1alpha1.PhaseCompleted || p == eraserv1alpha1.PhaseFailed)
+}
+
+func FilterJobListByOwner(jobs []eraserv1alpha1.ImageJob, owner metav1.OwnerReference) []eraserv1alpha1.ImageJob {
+	ret := []eraserv1alpha1.ImageJob{}
+
+	for i := range jobs {
+		job := jobs[i]
+
+		for j := range job.OwnerReferences {
+			or := job.OwnerReferences[j]
+
+			if or.UID == job.GetUID() {
+				ret = append(ret, job)
+				break // inner
+			}
+		}
+	}
+
+	return ret
 }

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	eraserv1alpha1 "github.com/Azure/eraser/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
@@ -34,4 +35,8 @@ func AlwaysOnGeneric(_ event.GenericEvent) bool {
 
 func AlwaysOnUpdate(_ event.UpdateEvent) bool {
 	return true
+}
+
+func IsCompletedOrFailed(p eraserv1alpha1.JobPhase) bool {
+	return (p == eraserv1alpha1.PhaseCompleted || p == eraserv1alpha1.PhaseFailed)
 }

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -1,0 +1,37 @@
+package util
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+func NeverOnCreate(_ event.CreateEvent) bool {
+	return false
+}
+
+func NeverOnDelete(_ event.DeleteEvent) bool {
+	return false
+}
+
+func NeverOnGeneric(_ event.GenericEvent) bool {
+	return false
+}
+
+func NeverOnUpdate(_ event.UpdateEvent) bool {
+	return false
+}
+
+func AlwaysOnCreate(_ event.CreateEvent) bool {
+	return true
+}
+
+func AlwaysOnDelete(_ event.DeleteEvent) bool {
+	return true
+}
+
+func AlwaysOnGeneric(_ event.GenericEvent) bool {
+	return true
+}
+
+func AlwaysOnUpdate(_ event.UpdateEvent) bool {
+	return true
+}

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -42,7 +42,7 @@ func IsCompletedOrFailed(p eraserv1alpha1.JobPhase) bool {
 	return (p == eraserv1alpha1.PhaseCompleted || p == eraserv1alpha1.PhaseFailed)
 }
 
-func FilterJobListByOwner(jobs []eraserv1alpha1.ImageJob, owner metav1.OwnerReference) []eraserv1alpha1.ImageJob {
+func FilterJobListByOwner(jobs []eraserv1alpha1.ImageJob, owner *metav1.OwnerReference) []eraserv1alpha1.ImageJob {
 	ret := []eraserv1alpha1.ImageJob{}
 
 	for i := range jobs {


### PR DESCRIPTION
**This PR is based on #204, please see the relevant diff here:**
https://github.com/pmengelbert/eraser/compare/fix_potential_reconciliation_bug...pmengelbert:eraser:move_imagejob_deletion_to_imagelist_controller

**What this PR does / why we need it**:
- Delete imagejob in imagelist controller, not from the imagejob controller.
- Update Imagelist status field in the imagelist controller, not in the imagejob controller.

This is necessary because:
- The `imagejob` is being repurposed for management of `collector` pods, and not just `eraser` pods.
- The `imagecollector controller` needs to monitor the `imagejob` to determine when it is completed, in order to proceed to the scanning phase.
- With the current behavior of the `imagejob controller`, the `imagejob` will be cleaned up once the `eraser` pods are finished, preventing the `imagecollector controller` from properly monitoring the `imagejob`.
- This issue will block further progress on the `imagecollector controller`, so it should be prioritized.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #200 
Based on top of PR #204, that one should be merged first

**Special notes for your reviewer**:
Please enjoy, and see commit messages for rationale and details