### PR TITLE
Use correct base image for output artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,10 +37,6 @@ RUN \
     --mount=type=cache,target=/go/pkg/mod \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags '-w -extldflags "-static"' -o out/eraser ./pkg/eraser
 
-FROM --platform=$BUILDPLATFORM $STATICBASEIMAGE as eraser
-COPY --from=eraser-build /workspace/out/eraser /
-ENTRYPOINT ["/eraser"]
-
 FROM builder AS collector-build
 
 RUN \
@@ -48,14 +44,17 @@ RUN \
     --mount=type=cache,target=/go/pkg/mod \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o out/collector ./pkg/collector
 
-FROM --platform=$BUILDPLATFORM $STATICBASEIMAGE as collector
+FROM --platform=$TARGETPLATFORM $STATICBASEIMAGE as collector
 COPY --from=collector-build /workspace/out/collector /
 ENTRYPOINT ["/collector"]
 
+FROM --platform=$TARGETPLATFORM $STATICBASEIMAGE as eraser
+COPY --from=eraser-build /workspace/out/eraser /
+ENTRYPOINT ["/eraser"]
+
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM --platform=$BUILDPLATFORM $STATICNONROOTBASEIMAGE AS manager
-WORKDIR /
+FROM --platform=$TARGETPLATFORM $STATICNONROOTBASEIMAGE AS manager
 COPY --from=manager-build /workspace/out/manager .
 USER 65532:65532
 ENTRYPOINT ["/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ ENTRYPOINT ["/eraser"]
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM --platform=$TARGETPLATFORM $STATICNONROOTBASEIMAGE AS manager
+WORKDIR /
 COPY --from=manager-build /workspace/out/manager .
 USER 65532:65532
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
**What this PR does / why we need it**:
In `Dockerfile`, the terminal stages that produce our images are using
`BUILDPLATFORM` to determine the architecture of the base image before
pulling in the static binary. It should be `TARGETPLATFORM`.
