### PR TITLE
Modify collector to report non-running images

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -47,7 +47,7 @@ func (c *client) listImages(ctx context.Context) (list []*pb.Image, err error) {
 	return util.ListImages(ctx, c.images)
 }
 
-func getAllImages(c Client) ([]eraserv1alpha1.Image, error) {
+func getImages(c Client) ([]eraserv1alpha1.Image, error) {
 	backgroundContext, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -56,20 +56,41 @@ func getAllImages(c Client) ([]eraserv1alpha1.Image, error) {
 		return nil, err
 	}
 
-	allImages := make([]eraserv1alpha1.Image, 0, len(images))
+	allImages := make([]string, 0, len(images))
+
+	// map with key: sha id, value: repoTag list (contains full name of image)
+	idToTagListMap := make(map[string][]string)
 
 	for _, img := range images {
-		currImage := eraserv1alpha1.Image{
-			Digest: img.Id,
-		}
-		if len(img.RepoTags) > 0 {
-			currImage.Name = img.RepoTags[0]
-		}
-
-		allImages = append(allImages, currImage)
+		allImages = append(allImages, img.Id)
+		idToTagListMap[img.Id] = img.RepoTags
 	}
 
-	return allImages, nil
+	containers, err := c.listContainers(backgroundContext)
+	if err != nil {
+		return nil, err
+	}
+
+	// Images that are running
+	// map of (digest | tag) -> digest
+	runningImages := util.GetRunningImages(containers, idToTagListMap)
+
+	// Images that aren't running
+	// map of (digest | tag) -> digest
+	nonRunningImages := util.GetNonRunningImages(runningImages, allImages, idToTagListMap)
+
+	finalImages := make([]eraserv1alpha1.Image, 0, len(images))
+
+	for digest, tag := range nonRunningImages {
+		currImage := eraserv1alpha1.Image{
+			Digest: digest,
+			Name:   tag,
+		}
+
+		finalImages = append(finalImages, currImage)
+	}
+
+	return finalImages, nil
 }
 
 func createCollectorCR(ctx context.Context, allImages []eraserv1alpha1.Image) error {
@@ -152,13 +173,13 @@ func main() {
 
 	client := &client{imageclient, runTimeClient}
 
-	allImages, err := getAllImages(client)
+	finalImages, err := getImages(client)
 	if err != nil {
 		log.Error(err, "failed to list all images")
 		os.Exit(1)
 	}
 
-	if err := createCollectorCR(context.Background(), allImages); err != nil {
+	if err := createCollectorCR(context.Background(), finalImages); err != nil {
 		log.Error(err, "Error creating ImageCollector CR")
 		os.Exit(1)
 	}

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -36,6 +36,11 @@ type client struct {
 
 type Client interface {
 	listImages(context.Context) ([]*pb.Image, error)
+	listContainers(context.Context) ([]*pb.Container, error)
+}
+
+func (c *client) listContainers(ctx context.Context) (list []*pb.Container, err error) {
+	return util.ListContainers(ctx, c.runtime)
 }
 
 func (c *client) listImages(ctx context.Context) (list []*pb.Image, err error) {

--- a/pkg/eraser/eraser.go
+++ b/pkg/eraser/eraser.go
@@ -35,12 +35,8 @@ type Client interface {
 	deleteImage(context.Context, string) error
 }
 
-func (c *client) listContainers(context.Context) (list []*pb.Container, err error) {
-	resp, err := c.runtime.ListContainers(context.Background(), new(pb.ListContainersRequest))
-	if err != nil {
-		return nil, err
-	}
-	return resp.Containers, nil
+func (c *client) listContainers(ctx context.Context) (list []*pb.Container, err error) {
+	return util.ListContainers(ctx, c.runtime)
 }
 
 func (c *client) listImages(ctx context.Context) (list []*pb.Image, err error) {
@@ -91,29 +87,11 @@ func removeImages(c Client, targetImages []string) error {
 
 	// Images that are running
 	// map of (digest | tag) -> digest
-	runningImages := make(map[string]string)
-	for _, container := range containers {
-		curr := container.Image
-		digest := curr.GetImage()
-		runningImages[digest] = digest
-
-		for _, tag := range idToTagListMap[digest] {
-			runningImages[tag] = digest
-		}
-	}
+	runningImages := util.GetRunningImages(containers, idToTagListMap)
 
 	// Images that aren't running
 	// map of (digest | tag) -> digest
-	nonRunningImages := make(map[string]string)
-	for _, digest := range allImages {
-		if _, isRunning := runningImages[digest]; !isRunning {
-			nonRunningImages[digest] = digest
-
-			for _, tag := range idToTagListMap[digest] {
-				nonRunningImages[tag] = digest
-			}
-		}
-	}
+	nonRunningImages := util.GetNonRunningImages(runningImages, allImages, idToTagListMap)
 
 	// Debug logs
 	log.V(1).Info("Map of non-running images", "nonRunningImages", nonRunningImages)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -94,3 +94,45 @@ func ListImages(ctx context.Context, images pb.ImageServiceClient) (list []*pb.I
 
 	return resp.Images, nil
 }
+
+func ListContainers(ctx context.Context, runtime pb.RuntimeServiceClient) (list []*pb.Container, err error) {
+	resp, err := runtime.ListContainers(context.Background(), new(pb.ListContainersRequest))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Containers, nil
+}
+
+func GetRunningImages(containers []*pb.Container, idToTagListMap map[string][]string) map[string]string {
+	// Images that are running
+	// map of (digest | tag) -> digest
+	runningImages := make(map[string]string)
+	for _, container := range containers {
+		curr := container.Image
+		digest := curr.GetImage()
+		runningImages[digest] = digest
+
+		for _, tag := range idToTagListMap[digest] {
+			runningImages[tag] = digest
+		}
+	}
+	return runningImages
+}
+
+func GetNonRunningImages(runningImages map[string]string, allImages []string, idToTagListMap map[string][]string) map[string]string {
+	// Images that aren't running
+	// map of (digest | tag) -> digest
+	nonRunningImages := make(map[string]string)
+
+	for _, digest := range allImages {
+		if _, isRunning := runningImages[digest]; !isRunning {
+			nonRunningImages[digest] = digest
+
+			for _, tag := range idToTagListMap[digest] {
+				nonRunningImages[tag] = digest
+			}
+		}
+	}
+
+	return nonRunningImages
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Modifies collector pods to report non-running images instead of all images.  Shares code in util with eraser pods.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
