### PR TITLE
docs: add links for the mailing list and community meeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ If you like to contribute to Eraser you need to setup your development environme
 
 ## Contributing
 
+There are several ways to get involved:
+* Join the [mailing list](https://groups.google.com/u/1/g/eraser-dev) to get notifications for releases, security announcements, etc.
+* Join the [biweekly community meetings](https://docs.google.com/document/d/1Sj5u47K3WUGYNPmQHGFpb52auqZb1FxSlWAQnPADhWI/edit) to discuss development, issues, use cases, etc.
+
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repos using our CLA.


### PR DESCRIPTION
**What this PR does / why we need it**:
Add info about the community meetings and mailing list.
