### PR TITLE
fix: Memory fix

### DIFF
--- a/controllers/imagecollector/imagecollector_controller.go
+++ b/controllers/imagecollector/imagecollector_controller.go
@@ -425,6 +425,13 @@ func (r *Reconciler) createScanJob(ctx context.Context, collector *eraserv1alpha
 							Name:  "trivy-scanner",
 							Image: scannerImage,
 							Args:  instanceArgs,
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"memory": resource.Quantity{
+										Format: "2Gi",
+									},
+								},
+							},
 						},
 					},
 				},

--- a/pkg/scanners/trivy/trivy.go
+++ b/pkg/scanners/trivy/trivy.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"sync"
 
 	machinerytypes "k8s.io/apimachinery/pkg/types"
 
@@ -119,11 +118,6 @@ type (
 		vulnerableImages []eraserv1alpha1.Image
 		failedImages     []eraserv1alpha1.Image
 	}
-
-	imageReport struct {
-		eraserv1alpha1.Image
-		err error
-	}
 )
 
 func main() {
@@ -200,97 +194,67 @@ func main() {
 	}
 
 	resultClient := initializeResultClient()
-	dbMutex := sync.Mutex{}
-	imgChan := make(chan imageReport)
-	var wg sync.WaitGroup
+	vulnerableImages := make([]eraserv1alpha1.Image, 0, len(result.Spec.Images))
+	failedImages := make([]eraserv1alpha1.Image, 0, len(result.Spec.Images))
 
 	for k := range result.Spec.Images {
 		img := result.Spec.Images[k]
-		wg.Add(1)
 
-		go func(img eraserv1alpha1.Image) {
-			imageRef := img.Name
-			if imageRef == "" {
-				log.Info("found image with no name", "img", img)
-				imgChan <- imageReport{Image: img, err: fmt.Errorf("no name")}
-				wg.Done()
-				return
-			}
-
-			log.Info("scanning image", "imageRef", imageRef)
-
-			// Reads db and cache and potentially modifies them, so lock all
-			// other threads during this operation
-			dbMutex.Lock()
-			dockerImage, cleanup, err := fanalImage.NewDockerImage(ctx, imageRef, scanConfig.dockerOptions)
-			defer cleanup()
-			dbMutex.Unlock()
-
-			if err != nil {
-				imgChan <- imageReport{Image: img, err: err}
-				log.Error(err, "error fetching manifest for image", "img", img)
-				wg.Done()
-				return
-			}
-
-			artifactToScan, err := artifactImage.NewArtifact(dockerImage, scanConfig.fscache, artifact.Option{})
-			if err != nil {
-				imgChan <- imageReport{Image: img, err: err}
-				log.Error(err, "error registering config for artifact", "img", img)
-				wg.Done()
-				return
-			}
-
-			scanner := scanner.NewScanner(scanConfig.localScanner, artifactToScan)
-			report, err := scanner.ScanArtifact(ctx, scanConfig.scanOptions)
-			if err != nil {
-				imgChan <- imageReport{Image: img, err: err}
-				log.Error(err, "error scanning image", "img", img)
-				wg.Done()
-				return
-			}
-
-		outer:
-			for i := range report.Results {
-				resultClient.FillVulnerabilityInfo(report.Results[i].Vulnerabilities, report.Results[i].Type)
-
-				for j := range report.Results[i].Vulnerabilities {
-					if *ignoreUnfixed && report.Results[i].Vulnerabilities[j].FixedVersion == "" {
-						continue
-					}
-
-					if report.Results[i].Vulnerabilities[j].Severity == "" {
-						report.Results[i].Vulnerabilities[j].Severity = severityUnknown
-					}
-
-					if severityMap[report.Results[i].Vulnerabilities[j].Severity] {
-						imgChan <- imageReport{Image: img, err: nil}
-						break outer
-					}
-				}
-			}
-
-			wg.Done()
-		}(img)
-	}
-
-	go func() {
-		wg.Wait()
-		close(imgChan)
-	}()
-
-	vulnerableImages := make([]eraserv1alpha1.Image, 0, len(result.Spec.Images))
-	failedImages := make([]eraserv1alpha1.Image, 0, len(result.Spec.Images))
-	for img := range imgChan {
-		if img.err != nil {
-			log.V(1).Error(img.err, "error scanning image") // debug only
-			failedImages = append(failedImages, img.Image)
-			log.Info("unable to scan image", "img", img)
+		imageRef := img.Name
+		if imageRef == "" {
+			log.Info("found image with no name", "img", img)
+			failedImages = append(failedImages, img)
 			continue
 		}
 
-		log.Info("image has vulnerabilities", "img", img)
-		vulnerableImages = append(vulnerableImages, img.Image)
+		log.Info("scanning image", "imageRef", imageRef)
+
+		dockerImage, cleanup, err := fanalImage.NewDockerImage(ctx, imageRef, scanConfig.dockerOptions)
+		if err != nil {
+			log.Error(err, "error fetching manifest for image", "img", img)
+			failedImages = append(failedImages, img)
+			cleanup()
+			continue
+		}
+
+		artifactToScan, err := artifactImage.NewArtifact(dockerImage, scanConfig.fscache, artifact.Option{})
+		if err != nil {
+			log.Error(err, "error registering config for artifact", "img", img)
+			failedImages = append(failedImages, img)
+			cleanup()
+			continue
+		}
+
+		scanner := scanner.NewScanner(scanConfig.localScanner, artifactToScan)
+		report, err := scanner.ScanArtifact(ctx, scanConfig.scanOptions)
+		if err != nil {
+			log.Error(err, "error scanning image", "img", img)
+			failedImages = append(failedImages, img)
+			cleanup()
+			continue
+		}
+
+	outer:
+		for i := range report.Results {
+			resultClient.FillVulnerabilityInfo(report.Results[i].Vulnerabilities, report.Results[i].Type)
+
+			for j := range report.Results[i].Vulnerabilities {
+				if *ignoreUnfixed && report.Results[i].Vulnerabilities[j].FixedVersion == "" {
+					continue
+				}
+
+				if report.Results[i].Vulnerabilities[j].Severity == "" {
+					report.Results[i].Vulnerabilities[j].Severity = severityUnknown
+				}
+
+				if severityMap[report.Results[i].Vulnerabilities[j].Severity] {
+					vulnerableImages = append(vulnerableImages, img)
+					break outer
+				}
+			}
+		}
+
+		cleanup()
 	}
 
 	err = updateStatus(&statusUpdate{


### PR DESCRIPTION
**What this PR does / why we need it**:
Our usage of goroutines for concurrent scanning results in very large memory consumption, probably due to a goroutine leak. In order to fix this, I have removed the goroutines and instead run the scanner sequentially. The scan job takes longer, but the memory consumption is kept under acceptable limits.

Before this fix, on a fresh AKS cluster memory consumption would reach up to 3Gi. After this fix, it stays below 500Mi.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #244 
