### PR TITLE
feat: Exclusion in collector pods

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -110,6 +110,7 @@ jobs:
         E2E_TEST:
           - collector_disable_scan
           - collector_pipeline
+          - collector_skip_excluded
           - imagelist_alias
           - imagelist_change
           - imagelist_exclusion_list

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ MANAGER_IMG ?= ghcr.io/azure/eraser-manager:${VERSION}
 ERASER_IMG ?= ghcr.io/azure/eraser:${VERSION}
 COLLECTOR_IMG ?= ghcr.io/azure/collector:${VERSION}
 VULNERABLE_IMG ?= docker.io/library/alpine:3.7.3
-E2E_TESTS ?= collector_disable_scan collector_pipeline imagelist_alias imagelist_change imagelist_prune_images imagelist_rm_images imagelist_skip_nodes imagelist_exclusion_list
+E2E_TESTS ?= collector_disable_scan collector_pipeline collector_skip_excluded imagelist_alias imagelist_change imagelist_prune_images imagelist_rm_images imagelist_skip_nodes imagelist_exclusion_list
 
 KUSTOMIZE_VERSION ?= 3.8.9
 KUBERNETES_VERSION ?= 1.23.0

--- a/controllers/imagecollector/imagecollector_controller.go
+++ b/controllers/imagecollector/imagecollector_controller.go
@@ -61,6 +61,8 @@ const (
 	collectorShared = "imagecollector-shared"
 	apiVersion      = "eraser.sh/v1alpha1"
 	namespace       = "eraser-system"
+	excludedPath    = "/run/eraser.sh/excluded"
+	excludedName    = "excluded"
 )
 
 func init() {
@@ -473,12 +475,23 @@ func (r *Reconciler) createImageJob(ctx context.Context, req ctrl.Request, image
 		Spec: eraserv1alpha1.ImageJobSpec{
 			JobTemplate: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: excludedName,
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: excludedName}, Optional: boolPtr(true)},
+							},
+						},
+					},
 					RestartPolicy: corev1.RestartPolicyNever,
 					Containers: []corev1.Container{
 						{
 							Name:            "collector",
 							Image:           *collectorImage,
 							ImagePullPolicy: corev1.PullIfNotPresent,
+							VolumeMounts: []corev1.VolumeMount{
+								{MountPath: excludedPath, Name: excludedName},
+							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("7m"),
@@ -559,4 +572,8 @@ func (r *Reconciler) deleteNodeCRS(ctx context.Context, items []eraserv1alpha1.I
 		}
 	}
 	return reconcile.Result{}, nil
+}
+
+func boolPtr(b bool) *bool {
+	return &b
 }

--- a/pkg/eraser/eraser.go
+++ b/pkg/eraser/eraser.go
@@ -8,8 +8,6 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
-	"regexp"
-	"strings"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -117,7 +115,7 @@ func removeImages(c Client, targetImages []string) error {
 		}
 
 		if digest, isNonRunning := nonRunningImages[imgDigestOrTag]; isNonRunning {
-			if ex := isExcluded(imgDigestOrTag, idToTagListMap); ex {
+			if ex := util.IsExcluded(excluded, imgDigestOrTag, idToTagListMap); ex {
 				log.Info("Image is excluded", "image", imgDigestOrTag)
 				continue
 			}
@@ -152,7 +150,7 @@ func removeImages(c Client, targetImages []string) error {
 				continue
 			}
 
-			if ex := isExcluded(img, idToTagListMap); ex {
+			if ex := util.IsExcluded(excluded, img, idToTagListMap); ex {
 				log.Info("Image is excluded", "image", img)
 				continue
 			}
@@ -166,63 +164,6 @@ func removeImages(c Client, targetImages []string) error {
 	}
 
 	return nil
-}
-
-func isExcluded(img string, idToTagListMap map[string][]string) bool {
-	// check if img excluded by digest
-	if _, contains := excluded[img]; contains {
-		return true
-	}
-
-	// check if img excluded by name
-	for _, imgName := range idToTagListMap[img] {
-		if _, contains := excluded[imgName]; contains {
-			return true
-		}
-	}
-
-	regexRepo := regexp.MustCompile(`[a-z0-9]+([._-][a-z0-9]+)*/\*\z`)
-	regexTag := regexp.MustCompile(`[a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+([._-][a-z0-9]+)*)*:\*\z`)
-
-	// look for excluded repository values and names without tag
-	for key := range excluded {
-		// if excluded key ends in /*, check image with pattern match
-		if match := regexRepo.MatchString(key); match {
-			// store repository name
-			repo := strings.Split(key, "*")
-
-			// check if img is part of repo
-			if match := strings.HasPrefix(img, repo[0]); match {
-				return true
-			}
-
-			// retrieve and check by name in the case img is digest
-			for _, imgName := range idToTagListMap[img] {
-				if match := strings.HasPrefix(imgName, repo[0]); match {
-					return true
-				}
-			}
-		}
-
-		// if excluded key ends in :*, check image with pattern patch
-		if match := regexTag.MatchString(key); match {
-			// store image name
-			imagePath := strings.Split(key, ":")
-
-			if match := strings.HasPrefix(img, imagePath[0]); match {
-				return true
-			}
-
-			// retrieve and check by name in the case img is digest
-			for _, imgName := range idToTagListMap[img] {
-				if match := strings.HasPrefix(imgName, imagePath[0]); match {
-					return true
-				}
-			}
-		}
-	}
-
-	return false
 }
 
 func main() {

--- a/test/e2e/collector_skip_excluded/eraser_test.go
+++ b/test/e2e/collector_skip_excluded/eraser_test.go
@@ -1,0 +1,90 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	eraserv1alpha1 "github.com/Azure/eraser/api/v1alpha1"
+	"github.com/Azure/eraser/test/e2e/util"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func TestCollectorExcluded(t *testing.T) {
+	collectorExcluded := features.New("ImageCollector should remove excluded images from imagecollector-shared").
+		Assess("ImageCollector CR is generated", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			c, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal("Failed to create new client", err)
+			}
+
+			// create excluded configmap and add docker.io/library/alpine
+			excluded := corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "excluded",
+					Namespace: "eraser-system",
+				},
+				Data: map[string]string{"excluded": "{\"excluded\": [\"docker.io/library/alpine\"]}"},
+			}
+			if err := cfg.Client().Resources().Create(ctx, &excluded); err != nil {
+				t.Error("failed to create excluded configmap", err)
+			}
+
+			resource := eraserv1alpha1.ImageCollector{}
+			wait.For(func() (bool, error) {
+				err := c.Resources().Get(ctx, util.ImageCollectorShared, "default", &resource)
+				if err != nil {
+					return false, err
+				}
+
+				if resource.ObjectMeta.Name == util.ImageCollectorShared {
+					return true, nil
+				}
+
+				return false, nil
+			}, wait.WithTimeout(time.Minute*3))
+
+			// alpine is excluded and should not be added to imagecollector-shared
+			for _, img := range resource.Spec.Images {
+				if strings.Contains("docker.io/library/alpine", img) {
+					return false, nil
+				}
+			}
+
+			return ctx
+		}).
+		Assess("Pods from imagejobs are cleaned up", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			c, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal("Failed to create new client", err)
+			}
+
+			var ls corev1.PodList
+			err = c.Resources().List(ctx, &ls, func(o *metav1.ListOptions) {
+				o.LabelSelector = labels.SelectorFromSet(map[string]string{"name": "collector"}).String()
+			})
+			if err != nil {
+				t.Errorf("could not list pods: %v", err)
+			}
+
+			err = wait.For(conditions.New(c.Resources()).ResourcesDeleted(&ls), wait.WithTimeout(time.Minute))
+			if err != nil {
+				t.Errorf("error waiting for pods to be deleted: %v", err)
+			}
+
+			return ctx
+		}).
+		Feature()
+
+	util.Testenv.Test(t, collectorExcluded)
+}

--- a/test/e2e/collector_skip_excluded/eraser_test.go
+++ b/test/e2e/collector_skip_excluded/eraser_test.go
@@ -58,6 +58,7 @@ func TestCollectorExcluded(t *testing.T) {
 			return ctx
 		}).
 		Assess("ImageList CR is generated", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			// check that imagelist CR is generated to make sure collection portion is completed
 			c, err := cfg.NewClient()
 			if err != nil {
 				t.Fatal("Failed to create new client", err)
@@ -83,22 +84,34 @@ func TestCollectorExcluded(t *testing.T) {
 
 			return ctx
 		}).
-		Assess("ImageList CR shared does not contain Alpine", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			resource := eraserv1alpha1.ImageCollector{}
-			err := c.Resources().Get(ctx, util.ImageCollectorShared, "default", &resource)
+		Assess("ImageCollector CR shared does not contain Alpine", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			c, err := cfg.NewClient()
 			if err != nil {
-				return false, err
+				t.Fatal("Failed to create new client", err)
 			}
+
+			resource := eraserv1alpha1.ImageCollector{}
+			wait.For(func() (bool, error) {
+				err := c.Resources().Get(ctx, util.ImageCollectorShared, "default", &resource)
+				if err != nil {
+					return false, err
+				}
+
+				if resource.ObjectMeta.Name == util.ImageCollectorShared {
+					return true, nil
+				}
+
+				return false, nil
+			}, wait.WithTimeout(time.Minute*3))
 
 			// alpine is excluded and should not be added to imagecollector-shared
 			for _, img := range resource.Spec.Images {
-				if strings.Contains("docker.io/library/alpine", img) {
-					return false, nil
+				if strings.Contains("docker.io/library/alpine", img.Name) {
+					t.Error("imagecollector-shared should not contains alpine", img.Name)
 				}
 			}
 
 			return ctx
-
 		}).
 		Assess("Pods from imagejobs are cleaned up", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			c, err := cfg.NewClient()

--- a/test/e2e/collector_skip_excluded/eraser_test.go
+++ b/test/e2e/collector_skip_excluded/eraser_test.go
@@ -134,27 +134,6 @@ func TestCollectorExcluded(t *testing.T) {
 
 			return ctx
 		}).
-		Assess("Pods from imagejobs are cleaned up", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			c, err := cfg.NewClient()
-			if err != nil {
-				t.Fatal("Failed to create new client", err)
-			}
-
-			var ls corev1.PodList
-			err = c.Resources().List(ctx, &ls, func(o *metav1.ListOptions) {
-				o.LabelSelector = labels.SelectorFromSet(map[string]string{"name": "collector"}).String()
-			})
-			if err != nil {
-				t.Errorf("could not list pods: %v", err)
-			}
-
-			err = wait.For(conditions.New(c.Resources()).ResourcesDeleted(&ls), wait.WithTimeout(time.Minute))
-			if err != nil {
-				t.Errorf("error waiting for pods to be deleted: %v", err)
-			}
-
-			return ctx
-		}).
 		Feature()
 
 	util.Testenv.Test(t, collectorExcluded)

--- a/test/e2e/collector_skip_excluded/eraser_test.go
+++ b/test/e2e/collector_skip_excluded/eraser_test.go
@@ -106,7 +106,7 @@ func TestCollectorExcluded(t *testing.T) {
 
 			// alpine is excluded and should not be added to imagecollector-shared
 			for _, img := range resource.Spec.Images {
-				if strings.Contains("docker.io/library/alpine", img.Name) {
+				if strings.Contains(img.Name, "alpine") {
 					t.Error("imagecollector-shared should not contains alpine", img.Name)
 				}
 			}

--- a/test/e2e/collector_skip_excluded/eraser_test.go
+++ b/test/e2e/collector_skip_excluded/eraser_test.go
@@ -35,7 +35,7 @@ func TestCollectorExcluded(t *testing.T) {
 					Name:      "excluded",
 					Namespace: "eraser-system",
 				},
-				Data: map[string]string{"excluded": "{\"excluded\": [\"docker.io/library/alpine\"]}"},
+				Data: map[string]string{"excluded": "{\"excluded\": [\"docker.io/library/alpine:*\"]}"},
 			}
 			if err := cfg.Client().Resources().Create(ctx, &excluded); err != nil {
 				t.Error("failed to create excluded configmap", err)
@@ -107,7 +107,7 @@ func TestCollectorExcluded(t *testing.T) {
 			// alpine is excluded and should not be added to imagecollector-shared
 			for _, img := range resource.Spec.Images {
 				if strings.Contains(img.Name, "alpine") {
-					t.Error("imagecollector-shared should not contains alpine", img.Name)
+					t.Error("imagecollector-shared should not contain alpine", img.Name)
 				}
 			}
 

--- a/test/e2e/collector_skip_excluded/main_test.go
+++ b/test/e2e/collector_skip_excluded/main_test.go
@@ -26,7 +26,6 @@ func TestMain(m *testing.M) {
 		envfuncs.CreateNamespace(util.Namespace),
 		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.ManagerImage),
 		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.Image),
-		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.ScannerImage),
 		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.CollectorImage),
 		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.VulnerableImage),
 		util.DeployEraserManifest(util.EraserNamespace, "--set", "scanner.image.repository="),

--- a/test/e2e/collector_skip_excluded/main_test.go
+++ b/test/e2e/collector_skip_excluded/main_test.go
@@ -1,0 +1,37 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"os"
+	"testing"
+
+	eraserv1alpha1 "github.com/Azure/eraser/api/v1alpha1"
+	"github.com/Azure/eraser/test/e2e/util"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/e2e-framework/pkg/env"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+)
+
+func TestMain(m *testing.M) {
+	utilruntime.Must(eraserv1alpha1.AddToScheme(scheme.Scheme))
+
+	util.Testenv = env.NewWithConfig(envconf.New())
+	// Create KinD Cluster
+	util.Testenv.Setup(
+		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, "../kind-config.yaml"),
+		envfuncs.CreateNamespace(util.Namespace),
+		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.ManagerImage),
+		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.Image),
+		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.ScannerImage),
+		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.CollectorImage),
+		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.VulnerableImage),
+		util.DeployEraserManifest(util.EraserNamespace),
+	).Finish(
+		envfuncs.DestroyKindCluster(util.KindClusterName),
+	)
+	os.Exit(util.Testenv.Run(m))
+}

--- a/test/e2e/collector_skip_excluded/main_test.go
+++ b/test/e2e/collector_skip_excluded/main_test.go
@@ -29,7 +29,7 @@ func TestMain(m *testing.M) {
 		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.ScannerImage),
 		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.CollectorImage),
 		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.VulnerableImage),
-		util.DeployEraserManifest(util.EraserNamespace),
+		util.DeployEraserManifest(util.EraserNamespace, "--set", "scanner.image.repository="),
 	).Finish(
 		envfuncs.DestroyKindCluster(util.KindClusterName),
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:
Collector pods reference excluded configmap to before adding images to final list of images for imagecollector-shared.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #274

**Special notes for your reviewer**:
