### PR TITLE
test: Use --wait flag in helm deployments for e2e tests

### DIFF
--- a/test/e2e/collector_skip_excluded/eraser_test.go
+++ b/test/e2e/collector_skip_excluded/eraser_test.go
@@ -10,15 +10,12 @@ import (
 
 	eraserv1alpha1 "github.com/Azure/eraser/api/v1alpha1"
 	"github.com/Azure/eraser/test/e2e/util"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
+
+	"strings"
 
 	"sigs.k8s.io/e2e-framework/klient/wait"
-	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
-	"strings"
 )
 
 func TestCollectorExcluded(t *testing.T) {
@@ -28,36 +25,6 @@ func TestCollectorExcluded(t *testing.T) {
 			if err != nil {
 				t.Fatal("Failed to create new client", err)
 			}
-
-			// create excluded configmap and add docker.io/library/alpine
-			excluded := corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "excluded",
-					Namespace: "eraser-system",
-				},
-				Data: map[string]string{"excluded": "{\"excluded\": [\"docker.io/library/alpine:*\"]}"},
-			}
-			if err := cfg.Client().Resources().Create(ctx, &excluded); err != nil {
-				t.Error("failed to create excluded configmap", err)
-			}
-
-			cMap := corev1.ConfigMap{}
-			wait.For(func() (bool, error) {
-				err := c.Resources().Get(ctx, "excluded", util.EraserNamespace, &cMap)
-				if util.IsNotFound(err) {
-					return false, nil
-				}
-
-				if err != nil {
-					return false, err
-				}
-
-				if cMap.ObjectMeta.Name == "excluded" {
-					return true, nil
-				}
-
-				return false, nil
-			}, wait.WithTimeout(time.Minute*3))
 
 			resource := eraserv1alpha1.ImageCollector{}
 			wait.For(func() (bool, error) {
@@ -127,27 +94,6 @@ func TestCollectorExcluded(t *testing.T) {
 				if strings.Contains(img.Name, "alpine") {
 					t.Error("imagecollector-shared should not contain alpine", img.Name)
 				}
-			}
-
-			return ctx
-		}).
-		Assess("Pods from imagejobs are cleaned up", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			c, err := cfg.NewClient()
-			if err != nil {
-				t.Fatal("Failed to create new client", err)
-			}
-
-			var ls corev1.PodList
-			err = c.Resources().List(ctx, &ls, func(o *metav1.ListOptions) {
-				o.LabelSelector = labels.SelectorFromSet(map[string]string{"name": "collector"}).String()
-			})
-			if err != nil {
-				t.Errorf("could not list pods: %v", err)
-			}
-
-			err = wait.For(conditions.New(c.Resources()).ResourcesDeleted(&ls), wait.WithTimeout(time.Minute))
-			if err != nil {
-				t.Errorf("error waiting for pods to be deleted: %v", err)
 			}
 
 			return ctx

--- a/test/e2e/collector_skip_excluded/eraser_test.go
+++ b/test/e2e/collector_skip_excluded/eraser_test.go
@@ -41,6 +41,24 @@ func TestCollectorExcluded(t *testing.T) {
 				t.Error("failed to create excluded configmap", err)
 			}
 
+			cMap := corev1.ConfigMap{}
+			wait.For(func() (bool, error) {
+				err := c.Resources().Get(ctx, "excluded", util.EraserNamespace, &cMap)
+				if util.IsNotFound(err) {
+					return false, nil
+				}
+
+				if err != nil {
+					return false, err
+				}
+
+				if cMap.ObjectMeta.Name == "excluded" {
+					return true, nil
+				}
+
+				return false, nil
+			}, wait.WithTimeout(time.Minute*3))
+
 			resource := eraserv1alpha1.ImageCollector{}
 			wait.For(func() (bool, error) {
 				err := c.Resources().Get(ctx, util.ImageCollectorShared, "default", &resource)

--- a/test/e2e/collector_skip_excluded/main_test.go
+++ b/test/e2e/collector_skip_excluded/main_test.go
@@ -14,6 +14,8 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+
+	pkgUtil "github.com/Azure/eraser/pkg/utils"
 )
 
 func TestMain(m *testing.M) {
@@ -24,10 +26,14 @@ func TestMain(m *testing.M) {
 	util.Testenv.Setup(
 		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, "../kind-config.yaml"),
 		envfuncs.CreateNamespace(util.Namespace),
+		envfuncs.CreateNamespace(util.EraserNamespace),
 		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.ManagerImage),
 		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.Image),
 		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.CollectorImage),
 		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.VulnerableImage),
+		util.CreateExclusionList(util.EraserNamespace, pkgUtil.ExclusionList{
+			Excluded: []string{"docker.io/library/alpine:*"},
+		}),
 		util.DeployEraserManifest(util.EraserNamespace, "--set", "scanner.image.repository="),
 	).Finish(
 		envfuncs.DestroyKindCluster(util.KindClusterName),

--- a/test/e2e/util/kubectl.go
+++ b/test/e2e/util/kubectl.go
@@ -26,6 +26,7 @@ func HelmInstall(kubeconfigPath, namespace string, args []string) error {
 	args = append([]string{
 		"install",
 		"eraser-e2e-test",
+		"--wait",
 		"--create-namespace",
 		fmt.Sprintf("--kubeconfig=%s", kubeconfigPath),
 		fmt.Sprintf("--namespace=%s", namespace),

--- a/test/e2e/util/kubectl.go
+++ b/test/e2e/util/kubectl.go
@@ -27,6 +27,7 @@ func HelmInstall(kubeconfigPath, namespace string, args []string) error {
 		"install",
 		"eraser-e2e-test",
 		"--wait",
+		"--debug",
 		"--create-namespace",
 		fmt.Sprintf("--kubeconfig=%s", kubeconfigPath),
 		fmt.Sprintf("--namespace=%s", namespace),

--- a/test/e2e/util/utils.go
+++ b/test/e2e/util/utils.go
@@ -433,7 +433,7 @@ func CreateExclusionList(namespace string, list pkgUtil.ExclusionList) env.Func 
 		}
 
 		cMap := corev1.ConfigMap{}
-		wait.For(func() (bool, error) {
+		err = wait.For(func() (bool, error) {
 			err := c.Resources().Get(ctx, "excluded", EraserNamespace, &cMap)
 			if IsNotFound(err) {
 				return false, nil
@@ -449,6 +449,9 @@ func CreateExclusionList(namespace string, list pkgUtil.ExclusionList) env.Func 
 
 			return false, nil
 		}, wait.WithTimeout(time.Minute*3))
+		if err != nil {
+			return ctx, err
+		}
 
 		return ctx, nil
 	}

--- a/test/e2e/util/utils.go
+++ b/test/e2e/util/utils.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -20,6 +21,8 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/kind/pkg/cluster"
+
+	pkgUtil "github.com/Azure/eraser/pkg/utils"
 )
 
 const (
@@ -400,6 +403,52 @@ func DeployEraserManifest(namespace string, args ...string) env.Func {
 
 			return ctx, err
 		}
+
+		return ctx, nil
+	}
+}
+
+func CreateExclusionList(namespace string, list pkgUtil.ExclusionList) env.Func {
+	return func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+		c, err := cfg.NewClient()
+		if err != nil {
+			return ctx, err
+		}
+
+		b, err := json.Marshal(&list)
+		if err != nil {
+			return ctx, err
+		}
+
+		// create excluded configmap and add docker.io/library/alpine
+		excluded := corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "excluded",
+				Namespace: "eraser-system",
+			},
+			Data: map[string]string{"excluded": string(b)},
+		}
+		if err := cfg.Client().Resources().Create(ctx, &excluded); err != nil {
+			return ctx, err
+		}
+
+		cMap := corev1.ConfigMap{}
+		wait.For(func() (bool, error) {
+			err := c.Resources().Get(ctx, "excluded", EraserNamespace, &cMap)
+			if IsNotFound(err) {
+				return false, nil
+			}
+
+			if err != nil {
+				return false, err
+			}
+
+			if cMap.ObjectMeta.Name == "excluded" {
+				return true, nil
+			}
+
+			return false, nil
+		}, wait.WithTimeout(time.Minute*3))
 
 		return ctx, nil
 	}


### PR DESCRIPTION
ADO pipelines appear to have issues with the helm deployments unless
`--wait` is supplied.

Signed-off-by: Peter Engelbert