### PR TITLE
feat: Enable helm args

### DIFF
--- a/manifest_staging/charts/eraser/templates/eraser-controller-manager-deployment.yaml
+++ b/manifest_staging/charts/eraser/templates/eraser-controller-manager-deployment.yaml
@@ -36,6 +36,7 @@ spec:
         - --collector-image={{ if .Values.collector.image.repository }}{{ .Values.collector.image.repository }}:{{ .Values.collector.image.tag | default .Chart.AppVersion }}{{ end }}
         - --scanner-image={{ if .Values.scanner.image.repository }}{{ .Values.scanner.image.repository }}:{{ .Values.scanner.image.tag | default .Chart.AppVersion }}{{ end }}
         {{- if .Values.scanner.image.args }}{{- range .Values.scanner.image.args }}{{ nindent 8 "- --scanner-arg=" }}{{ . }}{{- end -}}{{ end }}
+        {{- if .Values.controllerManager.image.additionalArgs }}{{- range .Values.controllerManager.image.additionalArgs }}{{ nindent 8 "- " }}{{ . }}{{- end -}}{{ end }}
         command:
         - /manager
         env:

--- a/manifest_staging/charts/eraser/values.yaml
+++ b/manifest_staging/charts/eraser/values.yaml
@@ -5,6 +5,7 @@ controllerManager:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
+    additionalArgs: []
 
   securityContext:
     allowPrivilegeEscalation: false

--- a/third_party/open-policy-agent/gatekeeper/helmify/kustomize-for-helm.yaml
+++ b/third_party/open-policy-agent/gatekeeper/helmify/kustomize-for-helm.yaml
@@ -14,6 +14,7 @@ spec:
         - --collector-image={{ if .Values.collector.image.repository }}{{ .Values.collector.image.repository }}:{{ .Values.collector.image.tag | default .Chart.AppVersion }}{{ end }}
         - --scanner-image={{ if .Values.scanner.image.repository }}{{ .Values.scanner.image.repository }}:{{ .Values.scanner.image.tag | default .Chart.AppVersion }}{{ end }}
         - HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_SCANNER_ARGS
+        - HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_ADDITIONAL_ARGS
         command:
         - /manager
         image: "{{ .Values.controllerManager.image.repository }}:{{ .Values.controllerManager.image.tag | default .Chart.AppVersion }}"

--- a/third_party/open-policy-agent/gatekeeper/helmify/replacements.go
+++ b/third_party/open-policy-agent/gatekeeper/helmify/replacements.go
@@ -6,4 +6,5 @@ var replacements = map[string]string{
 	`HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_TOLERATIONS: ""`:         `{{- toYaml .Values.controllerManager.tolerations | nindent 8 }}`,
 	`HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_AFFINITY: ""`:            `{{- toYaml .Values.controllerManager.affinity | nindent 8 }}`,
 	`- HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_SCANNER_ARGS`:          `{{- if .Values.scanner.image.args }}{{- range .Values.scanner.image.args }}{{ nindent 8 "- --scanner-arg=" }}{{ . }}{{- end -}}{{ end }}`,
+	`- HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_ADDITIONAL_ARGS`:       `{{- if .Values.controllerManager.image.additionalArgs }}{{- range .Values.controllerManager.image.additionalArgs }}{{ nindent 8 "- " }}{{ . }}{{- end -}}{{ end }}`,
 }

--- a/third_party/open-policy-agent/gatekeeper/helmify/static/values.yaml
+++ b/third_party/open-policy-agent/gatekeeper/helmify/static/values.yaml
@@ -5,6 +5,7 @@ controllerManager:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
+    additionalArgs: []
 
   securityContext:
     allowPrivilegeEscalation: false


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows the user to supply arbitrary manager flags using the helm chart. Example:
```bash
$ helm install eraser manifest_staging/charts/eraser --set 'controllerManager.image.additionalArgs={--foo=bar,--non=sense}'
```
