### PR TITLE
feat: Add controller flags to request/limit CPU/memory on scanner

### DIFF
--- a/controllers/imagecollector/imagecollector_controller.go
+++ b/controllers/imagecollector/imagecollector_controller.go
@@ -380,10 +380,16 @@ func (r *Reconciler) createScanJob(ctx context.Context, collector *eraserv1alpha
 									"memory": resource.Quantity{
 										Format: resource.Format(*util.ScannerMemRequest),
 									},
+									"cpu": resource.Quantity{
+										Format: resource.Format(*util.ScannerCPURequest),
+									},
 								},
 								Limits: corev1.ResourceList{
 									"memory": resource.Quantity{
 										Format: resource.Format(*util.ScannerMemLimit),
+									},
+									"cpu": resource.Quantity{
+										Format: resource.Format(*util.ScannerCPULimit),
 									},
 								},
 							},
@@ -392,19 +398,6 @@ func (r *Reconciler) createScanJob(ctx context.Context, collector *eraserv1alpha
 				},
 			},
 		},
-	}
-
-	resources := &scanJob.Spec.Template.Spec.Containers[0].Resources
-	if *util.ScannerCPURequest != "" {
-		resources.Requests["cpu"] = resource.Quantity{
-			Format: resource.Format(*util.ScannerCPURequest),
-		}
-	}
-
-	if *util.ScannerCPULimit != "" {
-		resources.Limits["cpu"] = resource.Quantity{
-			Format: resource.Format(*util.ScannerCPULimit),
-		}
 	}
 
 	return r.Create(ctx, &scanJob)

--- a/controllers/imagecollector/imagecollector_controller.go
+++ b/controllers/imagecollector/imagecollector_controller.go
@@ -376,9 +376,14 @@ func (r *Reconciler) createScanJob(ctx context.Context, collector *eraserv1alpha
 							Image: scannerImage,
 							Args:  instanceArgs,
 							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"memory": resource.Quantity{
+										Format: resource.Format(*util.ScannerMemRequest),
+									},
+								},
 								Limits: corev1.ResourceList{
 									"memory": resource.Quantity{
-										Format: "2Gi",
+										Format: resource.Format(*util.ScannerMemLimit),
 									},
 								},
 							},
@@ -387,6 +392,19 @@ func (r *Reconciler) createScanJob(ctx context.Context, collector *eraserv1alpha
 				},
 			},
 		},
+	}
+
+	resources := &scanJob.Spec.Template.Spec.Containers[0].Resources
+	if *util.ScannerCPURequest != "" {
+		resources.Requests["cpu"] = resource.Quantity{
+			Format: resource.Format(*util.ScannerCPURequest),
+		}
+	}
+
+	if *util.ScannerCPULimit != "" {
+		resources.Limits["cpu"] = resource.Quantity{
+			Format: resource.Format(*util.ScannerCPULimit),
+		}
 	}
 
 	return r.Create(ctx, &scanJob)

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -13,6 +13,11 @@ import (
 var (
 	SuccessDelDelaySeconds = flag.Int64("job-cleanup-on-success-delay", 0, "Seconds to delay job deletion after successful runs. 0 means no delay")
 	ErrDelDelaySeconds     = flag.Int64("job-cleanup-on-error-delay", 86400, "Seconds to delay job deletion after errored runs. 0 means no delay")
+
+	ScannerCPULimit   = flag.String("scanner-cpu-limit", "", "limit on CPU usage for scanner pods spawned by the eraser manager")
+	ScannerCPURequest = flag.String("scanner-cpu-request", "", "minimum CPU request for scanner pods spawned by the eraser manager")
+	ScannerMemLimit   = flag.String("scanner-mem-limit", "2Gi", "limit on memory usage for scanner pods spawned by the eraser manager")
+	ScannerMemRequest = flag.String("scanner-mem-request", "500Mi", "minimum memory request for scanner pods spawned by the eraser manager")
 )
 
 func NeverOnCreate(_ event.CreateEvent) bool {

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -14,10 +14,10 @@ var (
 	SuccessDelDelaySeconds = flag.Int64("job-cleanup-on-success-delay", 0, "Seconds to delay job deletion after successful runs. 0 means no delay")
 	ErrDelDelaySeconds     = flag.Int64("job-cleanup-on-error-delay", 86400, "Seconds to delay job deletion after errored runs. 0 means no delay")
 
-	ScannerCPULimit   = flag.String("scanner-cpu-limit", "", "limit on CPU usage for scanner pods spawned by the eraser manager")
-	ScannerCPURequest = flag.String("scanner-cpu-request", "", "minimum CPU request for scanner pods spawned by the eraser manager")
-	ScannerMemLimit   = flag.String("scanner-mem-limit", "2Gi", "limit on memory usage for scanner pods spawned by the eraser manager")
+	ScannerCPURequest = flag.String("scanner-cpu-request", "1000m", "minimum CPU request for scanner pods spawned by the eraser manager")
+	ScannerCPULimit   = flag.String("scanner-cpu-limit", "1500m", "limit on CPU usage for scanner pods spawned by the eraser manager")
 	ScannerMemRequest = flag.String("scanner-mem-request", "500Mi", "minimum memory request for scanner pods spawned by the eraser manager")
+	ScannerMemLimit   = flag.String("scanner-mem-limit", "2Gi", "limit on memory usage for scanner pods spawned by the eraser manager")
 )
 
 func NeverOnCreate(_ event.CreateEvent) bool {


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows the user to set CPU or Memory requests/limits for the scanner pods.

Resolves #241 