### PR TITLE
fix: Remove e2e test teardowns

### DIFF
--- a/test/e2e/tests/imagelist_change/eraser_test.go
+++ b/test/e2e/tests/imagelist_change/eraser_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	eraserv1alpha1 "github.com/Azure/eraser/api/v1alpha1"
 	"github.com/Azure/eraser/test/e2e/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/test/e2e/tests/imagelist_change/eraser_test.go
+++ b/test/e2e/tests/imagelist_change/eraser_test.go
@@ -137,23 +137,6 @@ func TestUpdateImageList(t *testing.T) {
 			util.CheckImageRemoved(ctxT, t, util.GetClusterNodes(t), util.Redis)
 
 			return ctx
-		}).
-		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			if i := ctx.Value(util.Nginx); i != nil {
-				cfg.Client().Resources().Delete(ctx, i.(*appsv1.Deployment))
-			}
-			if i := ctx.Value(util.Redis); i != nil {
-				cfg.Client().Resources().Delete(ctx, i.(*appsv1.Deployment))
-			}
-			if i := ctx.Value("imagelist"); i != nil {
-				cfg.Client().Resources().Delete(ctx, i.(*eraserv1alpha1.ImageList))
-			}
-
-			if err := util.DeleteImageListsAndJobs(cfg.KubeconfigFile()); err != nil {
-				t.Error("Failed to clean eraser obejcts ", err)
-			}
-
-			return ctx
 		}).Feature()
 
 	util.Testenv.Test(t, imglistChangeFeat)

--- a/test/e2e/tests/imagelist_exclusion_list/eraser_test.go
+++ b/test/e2e/tests/imagelist_exclusion_list/eraser_test.go
@@ -123,15 +123,6 @@ func TestExclusionList(t *testing.T) {
 
 			return ctx
 		}).
-		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			if err := util.DeleteEraserConfig(cfg.KubeconfigFile(), util.EraserNamespace, "../../test-data", "eraser_v1alpha1_imagelist.yaml"); err != nil {
-				t.Error("Failed to delete image list config ", err)
-			}
-			if err := util.DeleteImageListsAndJobs(cfg.KubeconfigFile()); err != nil {
-				t.Error("Failed to clean eraser obejcts ", err)
-			}
-			return ctx
-		}).
 		Feature()
 
 	util.Testenv.Test(t, excludedImageFeat)

--- a/test/e2e/tests/imagelist_prune_images/eraser_test.go
+++ b/test/e2e/tests/imagelist_prune_images/eraser_test.go
@@ -158,36 +158,6 @@ func TestPrune(t *testing.T) {
 
 			return ctx
 		}).
-		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			if i := ctx.Value(util.Nginx); i != nil {
-				cfg.Client().Resources().Delete(ctx, i.(*appsv1.Deployment))
-			}
-			if i := ctx.Value(util.Redis); i != nil {
-				cfg.Client().Resources().Delete(ctx, i.(*appsv1.Deployment))
-			}
-			if i := ctx.Value(util.Caddy); i != nil {
-				cfg.Client().Resources().Delete(ctx, i.(*appsv1.Deployment))
-			}
-			if i := ctx.Value(util.Prune); i != nil {
-				cfg.Client().Resources().Delete(ctx, i.(*eraserv1alpha1.ImageList))
-			}
-
-			if err := util.DeleteImageListsAndJobs(cfg.KubeconfigFile()); err != nil {
-				t.Error("Failed to clean eraser obejcts ", err)
-			}
-
-			// make sure nginx containers are cleaned up before proceeding
-			for _, nodeName := range util.GetClusterNodes(t) {
-				err := wait.For(util.ContainerNotPresentOnNode(nodeName, util.Nginx), wait.WithTimeout(time.Minute*2))
-				if err != nil {
-					// Let's not mark this as an error
-					// We only have this to prevent race conditions with the eraser spinning up
-					t.Logf("error while waiting for deployment deletion: %v", err)
-				}
-			}
-
-			return ctx
-		}).
 		Feature()
 
 	util.Testenv.Test(t, pruneImagesFeat)

--- a/test/e2e/tests/imagelist_rm_images/eraser_test.go
+++ b/test/e2e/tests/imagelist_rm_images/eraser_test.go
@@ -111,15 +111,6 @@ func TestImageListTriggersEraserImageJob(t *testing.T) {
 
 			return ctx
 		}).
-		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			if err := util.DeleteEraserConfig(cfg.KubeconfigFile(), util.EraserNamespace, "../../test-data", "eraser_v1alpha1_imagelist.yaml"); err != nil {
-				t.Error("Failed to delete image list config ", err)
-			}
-			if err := util.DeleteImageListsAndJobs(cfg.KubeconfigFile()); err != nil {
-				t.Error("Failed to clean eraser obejcts ", err)
-			}
-			return ctx
-		}).
 		Feature()
 
 	util.Testenv.Test(t, rmImageFeat)

--- a/test/e2e/tests/imagelist_skip_nodes/eraser_test.go
+++ b/test/e2e/tests/imagelist_skip_nodes/eraser_test.go
@@ -143,55 +143,6 @@ func TestSkipNodes(t *testing.T) {
 
 			return ctx
 		}).
-		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			if err := util.DeleteEraserConfig(cfg.KubeconfigFile(), util.EraserNamespace, "../../test-data", "eraser_v1alpha1_imagelist.yaml"); err != nil {
-				t.Error("Failed to delete image list config ", err)
-			}
-
-			c := cfg.Client().RESTConfig()
-			k8sClient, err := clientgo.NewForConfig(c)
-			if err != nil {
-				t.Error("unable to obtain k8s client from config", err)
-			}
-
-			nodeList, err := k8sClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: util.FilterNodeSelector})
-			if err != nil {
-				t.Errorf("unable to list node %s\n%#v", util.FilterNodeSelector, err)
-			}
-
-			if len(nodeList.Items) != 1 {
-				t.Errorf("List operation for selector %s resulted in the wrong number of nodes", util.FilterNodeSelector)
-			}
-
-			skippedNode := &nodeList.Items[0]
-			delete(skippedNode.ObjectMeta.Labels, util.FilterLabelKey)
-
-			skippedNode, err = k8sClient.CoreV1().Nodes().Update(ctx, skippedNode, metav1.UpdateOptions{})
-			if err != nil {
-				t.Errorf("unable to remove label %s from node %#v\nerror: %#v", util.FilterLabelKey, skippedNode, err)
-			}
-
-			err = wait.For(func() (bool, error) {
-				nodeList, err = k8sClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: util.FilterLabelKey})
-				if err != nil {
-					return false, err
-				}
-
-				return len(nodeList.Items) == 0, nil
-			}, wait.WithTimeout(time.Minute))
-			if err != nil {
-				t.Errorf("error while waiting for selector%s to be removed from node\n%#v", util.FilterNodeSelector, err)
-			}
-
-			if err := util.KubectlDelete(cfg.KubeconfigFile(), "", append([]string{"imagejob", "--all"})); err != nil {
-				t.Error("Failed to delete image job(s) config ", err)
-			}
-			if err := util.KubectlDelete(cfg.KubeconfigFile(), "", append([]string{"imagelist", "--all"})); err != nil {
-				t.Error("Failed to delete image job(s) config ", err)
-			}
-
-			return ctx
-		}).
 		Feature()
 
 	util.Testenv.Test(t, skipNodesFeat)


### PR DESCRIPTION
Each test has its own teardown section, which is no longer necessary.
They used to be used in between tests, but because we are running the
tests in parallel in the CI, we are now destroying the entire cluster
after each test. We can safely remove the teardown sections from each of
the e2e tests.

Resolves #302
