### PR TITLE
docs: add contributing and code of conduct docs to site

### DIFF
--- a/docs/docs/code-of-conduct.md
+++ b/docs/docs/code-of-conduct.md
@@ -1,0 +1,11 @@
+---
+title: Code of Conduct
+---
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+
+Resources:
+
+- [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
+- [Microsoft Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+- Contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with questions or concerns

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -1,0 +1,15 @@
+---
+title: Contributing
+---
+
+There are several ways to get involved with Eraser
+
+- Join the [mailing list](https://groups.google.com/u/1/g/eraser-dev) to get notifications for releases, security announcements, etc.
+- Participate in the [biweekly community meetings](https://docs.google.com/document/d/1Sj5u47K3WUGYNPmQHGFpb52auqZb1FxSlWAQnPADhWI/edit) to disucss development, issues, use cases, etc.
+- View the [development setup instructions](https://azure.github.io/eraser/docs/development)
+
+This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+
+When you submit a pull request, a CLA bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -36,7 +36,9 @@ const sidebars = {
         'setup',
         'releasing',
       ]
-    }
+    },
+    'contributing',
+    'code-of-conduct',
   ]
 };
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the contributing and code of conduct docs to the site. I am leaving them in the readme as well, just wanted them also present for those only visiting the site
