### PR TITLE
fix: security contexts for pods

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,12 +3,6 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-    pod-security.kubernetes.io/warn: restricted
-    pod-security.kubernetes.io/warn-version: latest
-    pod-security.kubernetes.io/audit: restricted
-    pod-security.kubernetes.io/audit-version: latest
-    pod-security.kubernetes.io/enforce: restricted
-    pod-security.kubernetes.io/enforce-version: v1.24
   name: system
 ---
 apiVersion: apps/v1

--- a/controllers/imagecollector/imagecollector_controller.go
+++ b/controllers/imagecollector/imagecollector_controller.go
@@ -410,6 +410,7 @@ func (r *Reconciler) createScanJob(ctx context.Context, collector *eraserv1alpha
 									},
 								},
 							},
+							SecurityContext: utils.SharedSecurityContext,
 						},
 					},
 				},
@@ -455,7 +456,7 @@ func (r *Reconciler) createImageJob(ctx context.Context, req ctrl.Request, image
 						{
 							Name: excludedName,
 							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: excludedName}, Optional: boolPtr(true)},
+								ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: excludedName}, Optional: utils.BoolPtr(true)},
 							},
 						},
 					},
@@ -479,6 +480,7 @@ func (r *Reconciler) createImageJob(ctx context.Context, req ctrl.Request, image
 									"memory": resource.MustParse("30Mi"),
 								},
 							},
+							SecurityContext: utils.SharedSecurityContext,
 						},
 					},
 					ServiceAccountName: "eraser-imagejob-pods",
@@ -549,10 +551,6 @@ func (r *Reconciler) deleteNodeCRS(ctx context.Context, items []eraserv1alpha1.I
 		}
 	}
 	return reconcile.Result{}, nil
-}
-
-func boolPtr(b bool) *bool {
-	return &b
 }
 
 func (r *Reconciler) handleCompletedImageJob(ctx context.Context, req ctrl.Request, imageCollectorShared *eraserv1alpha1.ImageCollector, childJob *eraserv1alpha1.ImageJob) (ctrl.Result, error) {

--- a/controllers/imagelist/imagelist_controller.go
+++ b/controllers/imagelist/imagelist_controller.go
@@ -193,7 +193,7 @@ func (r *Reconciler) handleImageListEvent(ctx context.Context, req *ctrl.Request
 			GenerateName: "imagelist-",
 			Namespace:    utils.GetNamespace(),
 		},
-		Immutable: boolPtr(true),
+		Immutable: utils.BoolPtr(true),
 		Data:      map[string]string{"images": string(imgListJSON)},
 	}
 	if err := r.Create(ctx, &configMap); err != nil {
@@ -227,7 +227,7 @@ func (r *Reconciler) handleImageListEvent(ctx context.Context, req *ctrl.Request
 						{
 							Name: excludedName,
 							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: excludedName}, Optional: boolPtr(true)},
+								ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: excludedName}, Optional: utils.BoolPtr(true)},
 							},
 						},
 					},
@@ -252,6 +252,7 @@ func (r *Reconciler) handleImageListEvent(ctx context.Context, req *ctrl.Request
 									"memory": resource.MustParse("30Mi"),
 								},
 							},
+							SecurityContext: utils.SharedSecurityContext,
 						},
 					},
 					ServiceAccountName: "eraser-imagejob-pods",
@@ -334,8 +335,4 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	return nil
-}
-
-func boolPtr(b bool) *bool {
-	return &b
 }

--- a/manifest_staging/deploy/eraser.yaml
+++ b/manifest_staging/deploy/eraser.yaml
@@ -3,12 +3,6 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-    pod-security.kubernetes.io/audit: restricted
-    pod-security.kubernetes.io/audit-version: latest
-    pod-security.kubernetes.io/enforce: restricted
-    pod-security.kubernetes.io/enforce-version: v1.24
-    pod-security.kubernetes.io/warn: restricted
-    pod-security.kubernetes.io/warn-version: latest
   name: eraser-system
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/pkg/utils/security_context.go
+++ b/pkg/utils/security_context.go
@@ -1,0 +1,14 @@
+package utils
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+var SharedSecurityContext = &corev1.SecurityContext{
+	Capabilities: &corev1.Capabilities{
+		Drop: []corev1.Capability{"ALL"},
+	},
+	SeccompProfile: &corev1.SeccompProfile{
+		Type: corev1.SeccompProfileTypeRuntimeDefault,
+	},
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -244,3 +244,7 @@ func ParseExcluded(path string) (map[string]struct{}, error) {
 
 	return excluded, nil
 }
+
+func BoolPtr(b bool) *bool {
+	return &b
+}


### PR DESCRIPTION
Signed-off-by: Sertac Ozercan <sozercan@gmail.com>

**What this PR does / why we need it**:
reverts #334 partially
add security contexts for eraser, scanner, collector 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #340 

**Special notes for your reviewer**:
