### PR TITLE
fix: add configmap watch rbac

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -12,6 +12,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/controllers/imagejob/imagejob_controller.go
+++ b/controllers/imagejob/imagejob_controller.go
@@ -144,7 +144,7 @@ func checkNodeFitness(pod *corev1.Pod, node *corev1.Node) bool {
 
 //+kubebuilder:rbac:groups=eraser.sh,resources=imagejobs,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=eraser.sh,resources=imagejobs/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/manifest_staging/charts/eraser/templates/eraser-manager-role-clusterrole.yaml
+++ b/manifest_staging/charts/eraser/templates/eraser-manager-role-clusterrole.yaml
@@ -16,6 +16,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/manifest_staging/deploy/eraser.yaml
+++ b/manifest_staging/deploy/eraser.yaml
@@ -4137,6 +4137,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
Manager logs report an error of failing to watch configmaps:

 {"level":"error","ts":1660752774.0649443,"msg":"pkg/mod/k8s.io/client-go@v0.22.9/tools/cache/reflector.go:167: Failed to watch *v1.ConfigMap: unknown (get configmaps)\n","stacktrace":"k8s.io/client-go/tools/cache.(*Reflector).Run.func1\n\t/go/pkg/mod/k8s.io/client-go@v0.22.9/tools/cache/reflector.go:222\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/go/pkg/mod/k8s.io/apimachinery@v0.22.9/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/go/pkg/mod/k8s.io/apimachinery@v0.22.9/pkg/util/wait/wait.go:156\nk8s.io/client-go/tools/cache.(*Reflector).Run\n\t/go/pkg/mod/k8s.io/client-go@v0.22.9/tools/cache/reflector.go:220\nk8s.io/apimachinery/pkg/util/wait.(*Group).StartWithChannel.func1\n\t/go/pkg/mod/k8s.io/apimachinery@v0.22.9/pkg/util/wait/wait.go:56\nk8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1\n\t/go/pkg/mod/k8s.io/apimachinery@v0.22.9/pkg/util/wait/wait.go:73"}

Adds configmap watch permission back to eraser manager role to remove error.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
