### PR TITLE
fix: add ReadHeaderTimeout for pprof profiling

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -70,7 +71,11 @@ func main() {
 
 	if *enableProfile {
 		go func() {
-			err := http.ListenAndServe(fmt.Sprintf("localhost:%d", *profilePort), nil)
+			server := &http.Server{
+				Addr:              fmt.Sprintf("localhost:%d", *profilePort),
+				ReadHeaderTimeout: 3 * time.Second,
+			}
+			err := server.ListenAndServe()
 			setupLog.Error(err, "pprof server failed")
 		}()
 	}

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -35,7 +35,11 @@ func main() {
 
 	if *enableProfile {
 		go func() {
-			err := http.ListenAndServe(fmt.Sprintf("localhost:%d", *profilePort), nil)
+			server := &http.Server{
+				Addr:              fmt.Sprintf("localhost:%d", *profilePort),
+				ReadHeaderTimeout: 3 * time.Second,
+			}
+			err := server.ListenAndServe()
 			log.Error(err, "pprof server failed")
 		}()
 	}

--- a/pkg/eraser/eraser.go
+++ b/pkg/eraser/eraser.go
@@ -38,9 +38,14 @@ const (
 
 func main() {
 	flag.Parse()
+
 	if *enableProfile {
 		go func() {
-			err := http.ListenAndServe(fmt.Sprintf("localhost:%d", *profilePort), nil)
+			server := &http.Server{
+				Addr:              fmt.Sprintf("localhost:%d", *profilePort),
+				ReadHeaderTimeout: 3 * time.Second,
+			}
+			err := server.ListenAndServe()
 			log.Error(err, "pprof server failed")
 		}()
 	}

--- a/pkg/scanners/trivy/trivy.go
+++ b/pkg/scanners/trivy/trivy.go
@@ -110,7 +110,11 @@ func main() {
 
 	if *enableProfile {
 		go func() {
-			err := http.ListenAndServe(fmt.Sprintf("localhost:%d", *profilePort), nil)
+			server := &http.Server{
+				Addr:              fmt.Sprintf("localhost:%d", *profilePort),
+				ReadHeaderTimeout: 3 * time.Second,
+			}
+			err := server.ListenAndServe()
 			log.Error(err, "pprof server failed")
 		}()
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes new lint error:  _G114: Use of net/http serve function that has no support for setting timeouts (gosec)_

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
