### PR TITLE
docs: fix small type in quick start doc

### DIFF
--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: alpine
-        image:docker.io/library/alpine:3.7.3
+        image: docker.io/library/alpine:3.7.3
 EOF
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:
There's a small typo in the quick start doc that causes the deamonset apply to fail. This should fix that.

