### PR TITLE
fix: show pods as running during collect-scan-erase pipeline

### DIFF
--- a/manifest_staging/deploy/eraser.yaml
+++ b/manifest_staging/deploy/eraser.yaml
@@ -4417,8 +4417,8 @@ spec:
       containers:
       - args:
         - --leader-elect=false
-        - --eraser-image=eraser:test
-        - --collector-image=collector:test
+        - --eraser-image=ghcr.io/azure/eraser:v0.4.0
+        - --collector-image=ghcr.io/azure/collector:v0.4.0
         - --scanner-image=ghcr.io/azure/eraser-trivy-scanner:v0.4.0
         command:
         - /manager

--- a/manifest_staging/deploy/eraser.yaml
+++ b/manifest_staging/deploy/eraser.yaml
@@ -4417,8 +4417,8 @@ spec:
       containers:
       - args:
         - --leader-elect=false
-        - --eraser-image=ghcr.io/azure/eraser:v0.4.0
-        - --collector-image=ghcr.io/azure/collector:v0.4.0
+        - --eraser-image=eraser:test
+        - --collector-image=collector:test
         - --scanner-image=ghcr.io/azure/eraser-trivy-scanner:v0.4.0
         command:
         - /manager

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -90,51 +90,49 @@ func main() {
 	}
 
 	path := util.CollectScanPath
-	pipeName := "scanErase"
 
 	if *scanDisabled {
 		path = util.ScanErasePath
-		pipeName = "collectScan"
 	}
 
 	if err := unix.Mkfifo(path, util.PipeMode); err != nil {
-		log.Error(err, "failed to create pipe", "pipeName", pipeName)
+		log.Error(err, "failed to create pipe", "pipeFile", path)
 		os.Exit(1)
 	}
 
 	file, err := os.OpenFile(path, os.O_WRONLY, 0)
 	if err != nil {
-		log.Error(err, "failed to open pipe", "pipeName", pipeName)
+		log.Error(err, "failed to open pipe", "pipeFile", path)
 		os.Exit(1)
 	}
 
 	if _, err := file.Write(data); err != nil {
-		log.Error(err, "failed to write to pipe", "pipeName", pipeName)
+		log.Error(err, "failed to write to pipe", "pipeFile", path)
 		os.Exit(1)
 	}
 
 	file.Close()
 	if err := unix.Mkfifo(util.EraseCompleteCollectPath, util.PipeMode); err != nil {
-		log.Error(err, "failed to create pipe", "pipeName", "eraseComplete")
+		log.Error(err, "failed to create pipe", "pipeFile", util.EraseCompleteCollectPath)
 		os.Exit(1)
 	}
 
 	file, err = os.OpenFile(util.EraseCompleteCollectPath, os.O_RDONLY, 0)
 	if err != nil {
-		log.Error(err, "failed to open pipe", "pipeName", "eraseComplete")
+		log.Error(err, "failed to open pipe", "pipeFile", util.EraseCompleteCollectPath)
 		os.Exit(1)
 	}
 
 	data, err = io.ReadAll(file)
 	if err != nil {
-		log.Error(err, "failed to read pipe", "pipeName", "eraseComplete")
+		log.Error(err, "failed to read pipe", "pipeFile", util.EraseCompleteCollectPath)
 		os.Exit(1)
 	}
 
 	file.Close()
 
 	if string(data) != util.EraseCompleteMessage {
-		log.Info("garbage in pipe", "pipeName", "eraseComplete", "in_pipe", string(data))
+		log.Info("garbage in pipe", "pipeFile", util.EraseCompleteCollectPath, "in_pipe", string(data))
 		os.Exit(1)
 	}
 }

--- a/pkg/eraser/eraser.go
+++ b/pkg/eraser/eraser.go
@@ -141,7 +141,7 @@ func main() {
 			os.Exit(generalErr)
 		}
 
-		if _, err := file.Write([]byte(util.EraseCompleteMessage)); err != nil {
+		if _, err := file.WriteString(util.EraseCompleteMessage); err != nil {
 			log.Error(err, "unable to write to pipe", "pipeFile", util.EraseCompleteCollectPath)
 			os.Exit(generalErr)
 		}
@@ -158,7 +158,7 @@ func main() {
 			os.Exit(generalErr)
 		}
 
-		if _, err := file.Write([]byte(util.EraseCompleteMessage)); err != nil {
+		if _, err := file.WriteString(util.EraseCompleteMessage); err != nil {
 			log.Error(err, "unable to write to pipe", "pipeFile", util.EraseCompleteCollectPath)
 			os.Exit(generalErr)
 		}

--- a/pkg/eraser/eraser.go
+++ b/pkg/eraser/eraser.go
@@ -134,29 +134,35 @@ func main() {
 		os.Exit(generalErr)
 	}
 
-	file, err := os.OpenFile(util.EraseCompleteCollectPath, os.O_WRONLY, 0)
-	if err != nil {
-		log.Error(err, "unable to open pipe", "pipeName", "eraseComplete")
-		os.Exit(generalErr)
+	if *imageListPtr == "" {
+		file, err := os.OpenFile(util.EraseCompleteCollectPath, os.O_WRONLY, 0)
+		if err != nil {
+			log.Error(err, "unable to open pipe", "pipeFile", util.EraseCompleteCollectPath)
+			os.Exit(generalErr)
+		}
+
+		if _, err := file.Write([]byte(util.EraseCompleteMessage)); err != nil {
+			log.Error(err, "unable to write to pipe", "pipeFile", util.EraseCompleteCollectPath)
+			os.Exit(generalErr)
+		}
+
+		file.Close()
+
+		file, err = os.OpenFile(util.EraseCompleteScanPath, os.O_WRONLY, fs.ModeNamedPipe)
+		// if the scanner is disabled
+		if os.IsNotExist(err) {
+			return
+		}
+		if err != nil {
+			log.Error(err, "unable to open pipe", "pipeFile", util.EraseCompleteCollectPath)
+			os.Exit(generalErr)
+		}
+
+		if _, err := file.Write([]byte(util.EraseCompleteMessage)); err != nil {
+			log.Error(err, "unable to write to pipe", "pipeFile", util.EraseCompleteCollectPath)
+			os.Exit(generalErr)
+		}
+
+		file.Close()
 	}
-
-	if _, err := file.Write([]byte(util.EraseCompleteMessage)); err != nil {
-		log.Error(err, "unable to write to pipe", "pipeName", "eraseComplete")
-		os.Exit(generalErr)
-	}
-
-	file.Close()
-
-	file, err = os.OpenFile(util.EraseCompleteScanPath, os.O_WRONLY, fs.ModeNamedPipe)
-	if err != nil {
-		log.Error(err, "unable to open pipe", "pipeName", "eraseComplete")
-		os.Exit(generalErr)
-	}
-
-	if _, err := file.Write([]byte(util.EraseCompleteMessage)); err != nil {
-		log.Error(err, "unable to write to pipe", "pipeName", "eraseComplete")
-		os.Exit(generalErr)
-	}
-
-	file.Close()
 }

--- a/pkg/scanners/trivy/trivy.go
+++ b/pkg/scanners/trivy/trivy.go
@@ -108,10 +108,15 @@ func main() {
 	trivylogger.Logger = sugar
 
 	if err := unix.Mkfifo(util.EraseCompleteScanPath, util.PipeMode); err != nil {
-		log.Error(err, "failed to create pipe", "pipeName", "eraseCompleteScan")
+		log.Error(err, "failed to create pipe", "pipeName", util.EraseCompleteScanPath)
 		os.Exit(1)
 	}
-	os.Chmod(util.EraseCompleteScanPath, 0o666)
+
+	err = os.Chmod(util.EraseCompleteScanPath, 0o666)
+	if err != nil {
+		log.Error(err, "unable to enable pipe for writing", "pipeName", util.EraseCompleteScanPath)
+		os.Exit(1)
+	}
 
 	if *enableProfile {
 		go func() {
@@ -250,20 +255,20 @@ func main() {
 
 	file, err := os.OpenFile(util.EraseCompleteScanPath, os.O_RDONLY, 0)
 	if err != nil {
-		log.Error(err, "failed to open pipe", "pipeName", "eraseCompleteScan")
+		log.Error(err, "failed to open pipe", "pipeName", util.EraseCompleteScanPath)
 		os.Exit(1)
 	}
 
 	data, err := io.ReadAll(file)
 	if err != nil {
-		log.Error(err, "failed to read pipe", "pipeName", "eraseCompleteScan")
+		log.Error(err, "failed to read pipe", "pipeName", util.EraseCompleteScanPath)
 		os.Exit(1)
 	}
 
 	file.Close()
 
 	if string(data) != util.EraseCompleteMessage {
-		log.Info("garbage in pipe", "pipeName", "eraseCompleteScan", "in_pipe", string(data))
+		log.Info("garbage in pipe", "pipeName", util.EraseCompleteScanPath, "in_pipe", string(data))
 		os.Exit(1)
 	}
 	log.Info("scanning complete, exiting")

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -22,10 +22,13 @@ import (
 
 const (
 	// unixProtocol is the network protocol of unix socket.
-	unixProtocol    = "unix"
-	PipeMode        = 0o644
-	ScanErasePath   = "/run/eraser.sh/shared-data/scanErase"
-	CollectScanPath = "/run/eraser.sh/shared-data/collectScan"
+	unixProtocol             = "unix"
+	PipeMode                 = 0o644
+	ScanErasePath            = "/run/eraser.sh/shared-data/scanErase"
+	CollectScanPath          = "/run/eraser.sh/shared-data/collectScan"
+	EraseCompleteCollectPath = "/run/eraser.sh/shared-data/eraseCompleteCollect"
+	EraseCompleteMessage     = "complete"
+	EraseCompleteScanPath    = "/run/eraser.sh/shared-data/eraseCompleteScan"
 )
 
 type ExclusionList struct {


### PR DESCRIPTION
Signed-off-by: Peter Engelbert

**What this PR does / why we need it**:
The collector pods (containing the collector, scanner, and eraser containers) were showing as "NotReady" throughout the duration of the ImageJob. This was because when the collector pod finished its work, its process would end and therefore it would be seen as "Ready: false".

This PR resolves the issue by creating a new named pipe in both the collector and scanner containers. These pipes are opened immediately for reading, which blocks the cleanup of the collector and scanner containers. When the eraser pod finishes its work, it writes to and closes the collector and scanner completion named pipes. This stops the blocking on the read end, allowing all containers to shut down at roughly the same time. The end result is a transition from `Running` to `Completed` status for the collector pods.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #395 