### PR TITLE
fix: label child imagejobs by owner

### DIFF
--- a/controllers/imagecollector/imagecollector_controller.go
+++ b/controllers/imagecollector/imagecollector_controller.go
@@ -217,7 +217,7 @@ func (r *Reconciler) createImageJob(ctx context.Context, req ctrl.Request, argsC
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "imagejob-",
 			Labels: map[string]string{
-				ownerLabelKey: ownerLabelValue,
+				util.ImageJobOwnerLabelKey: ownerLabelValue,
 			},
 		},
 		Spec: eraserv1alpha1.ImageJobSpec{

--- a/controllers/imagelist/imagelist_controller.go
+++ b/controllers/imagelist/imagelist_controller.go
@@ -213,6 +213,9 @@ func (r *Reconciler) handleImageListEvent(ctx context.Context, req *ctrl.Request
 	job := &eraserv1alpha1.ImageJob{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "imagejob-",
+			Labels: map[string]string{
+				util.ImageJobOwnerLabelKey: ownerLabelValue,
+			},
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(imageList, imageList.GroupVersionKind()),
 			},

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -27,6 +27,8 @@ var (
 )
 
 const (
+	ImageJobOwnerLabelKey = "eraser.sh/job-owner"
+
 	exclusionLabel = "eraser.sh/exclude.list=true"
 )
 

--- a/test/e2e/tests/imagelist_rm_images/eraser_test.go
+++ b/test/e2e/tests/imagelist_rm_images/eraser_test.go
@@ -37,7 +37,11 @@ func TestImageListTriggersEraserImageJob(t *testing.T) {
 
 			client := cfg.Client()
 			// wait for all collector pods to be present before removing them
-			err := wait.For(util.NumPodsPresentForLabel(ctx, client, 3, collectorLabel), wait.WithTimeout(time.Minute*2), wait.WithInterval(time.Millisecond*500))
+			err := wait.For(
+				util.NumPodsPresentForLabel(ctx, client, 3, collectorLabel),
+				wait.WithTimeout(time.Minute*2),
+				wait.WithInterval(time.Millisecond*500),
+			)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -47,12 +51,15 @@ func TestImageListTriggersEraserImageJob(t *testing.T) {
 			}
 
 			// wait for collector deployment to be removed, to prevent conflicts or races
-			err = wait.For(util.NumPodsPresentForLabel(ctx, client, 0, collectorLabel), wait.WithTimeout(time.Minute*2), wait.WithInterval(time.Millisecond*500))
+			err = wait.For(
+				util.NumPodsPresentForLabel(ctx, client, 0, collectorLabel),
+				wait.WithTimeout(time.Minute*2),
+				wait.WithInterval(time.Millisecond*500),
+			)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			//if err := wait.For(conditions.New(client.Resources().DeploymentConditionMatch()))
 			return ctx
 		}).
 		Assess("deployment successfully deployed", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {

--- a/test/e2e/tests/imagelist_rm_images/eraser_test.go
+++ b/test/e2e/tests/imagelist_rm_images/eraser_test.go
@@ -14,10 +14,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 	"sigs.k8s.io/e2e-framework/klient/wait"
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+const (
+	collectorLabel = "name=collector"
+	eraserLabel    = "name=eraser"
 )
 
 func TestImageListTriggersEraserImageJob(t *testing.T) {
@@ -28,9 +34,25 @@ func TestImageListTriggersEraserImageJob(t *testing.T) {
 			if err := cfg.Client().Resources().Create(ctx, nginxDep); err != nil {
 				t.Error("Failed to create the dep", err)
 			}
+
+			client := cfg.Client()
+			// wait for all collector pods to be present before removing them
+			err := wait.For(util.NumPodsPresentForLabel(ctx, client, 3, collectorLabel), wait.WithTimeout(time.Minute*2), wait.WithInterval(time.Millisecond*500))
+			if err != nil {
+				t.Fatal(err)
+			}
+
 			if err := util.DeleteImageListsAndJobs(cfg.KubeconfigFile()); err != nil {
 				t.Error("Failed to clean eraser obejcts ", err)
 			}
+
+			// wait for collector deployment to be removed, to prevent conflicts or races
+			err = wait.For(util.NumPodsPresentForLabel(ctx, client, 0, collectorLabel), wait.WithTimeout(time.Minute*2), wait.WithInterval(time.Millisecond*500))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			//if err := wait.For(conditions.New(client.Resources().DeploymentConditionMatch()))
 			return ctx
 		}).
 		Assess("deployment successfully deployed", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
@@ -84,17 +106,74 @@ func TestImageListTriggersEraserImageJob(t *testing.T) {
 				t.Error("Failed to deploy image list config", err)
 			}
 
+			podNames := []string{}
+			// get eraser pod name
+			err = wait.For(func() (bool, error) {
+				l := corev1.PodList{}
+				err = client.Resources().List(ctx, &l, resources.WithLabelSelector("name=eraser"))
+				if err != nil {
+					return false, err
+				}
+
+				if len(l.Items) != 3 {
+					return false, nil
+				}
+
+				for _, pod := range l.Items {
+					podNames = append(podNames, pod.ObjectMeta.Name)
+				}
+				return true, nil
+			}, wait.WithTimeout(time.Minute*2), wait.WithInterval(time.Millisecond*500))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// wait for those specific pods to no longer exist, so that when we
+			// check later for an accidental redeployment, we are sure it is
+			// actually a new deployment.
+			err = wait.For(func() (bool, error) {
+				var l corev1.PodList
+				err = client.Resources().List(ctx, &l, resources.WithLabelSelector("name=eraser"))
+				if err != nil {
+					return false, err
+				}
+
+				if len(l.Items) == 0 {
+					return true, nil
+				}
+
+				for _, name := range podNames {
+					for _, pod := range l.Items {
+						if name == pod.ObjectMeta.Name {
+							return false, nil
+						}
+					}
+				}
+
+				return true, nil
+			}, wait.WithTimeout(time.Minute*2), wait.WithInterval(time.Millisecond*500))
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("initial eraser deployment cleaned up")
+
 			ctxT, cancel := context.WithTimeout(ctx, time.Minute*3)
 			defer cancel()
 			util.CheckImageRemoved(ctxT, t, util.GetClusterNodes(t), util.Nginx)
 
 			return ctx
 		}).
-		Assess("Get logs", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			if err := util.GetPodLogs(ctx, cfg, t, true); err != nil {
-				t.Error("error getting collector pod logs", err)
-			}
+		Assess("Eraser job was not restarted", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			// until a timeout is reached, make sure there are no pods matching
+			// the selector name=eraser
+			client := cfg.Client()
+			ctxT2, cancel := context.WithTimeout(ctx, time.Minute*1)
+			defer cancel()
+			util.CheckDeploymentCleanedUp(ctxT2, t, client)
 
+			return ctx
+		}).
+		Assess("Get logs", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			if err := util.GetManagerLogs(ctx, cfg, t); err != nil {
 				t.Error("error getting manager logs", err)
 			}

--- a/test/e2e/tests/imagelist_rm_images/main_test.go
+++ b/test/e2e/tests/imagelist_rm_images/main_test.go
@@ -21,6 +21,7 @@ func TestMain(m *testing.M) {
 
 	eraserImage := util.ParsedImages.EraserImage
 	managerImage := util.ParsedImages.ManagerImage
+	collectorImage := util.ParsedImages.CollectorImage
 
 	util.Testenv = env.NewWithConfig(envconf.New())
 	// Create KinD Cluster
@@ -30,13 +31,14 @@ func TestMain(m *testing.M) {
 		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.ManagerImage),
 		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.Image),
 		util.DeployEraserHelm(util.EraserNamespace,
-			"--set", util.CollectorImageRepo.Set(""),
 			"--set", util.ScannerImageRepo.Set(""),
+			"--set", util.CollectorImageRepo.Set(collectorImage.Repo),
+			"--set", util.CollectorImageTag.Set(collectorImage.Tag),
 			"--set", util.EraserImageRepo.Set(eraserImage.Repo),
 			"--set", util.EraserImageTag.Set(eraserImage.Tag),
 			"--set", util.ManagerImageRepo.Set(managerImage.Repo),
 			"--set", util.ManagerImageTag.Set(managerImage.Tag),
-			"--set", `controllerManager.additionalArgs={--job-cleanup-on-success-delay=1m}`),
+		),
 	).Finish(
 		envfuncs.DestroyKindCluster(util.KindClusterName),
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:

Prior to PR #339, the ImageCollector controller was able to filter out ImageJob events related to ImageJobs created by the ImageList controller. Because the ImageCollector CR was removed, we could no longer keep the `&handler.EnqueueRequestForOwner` condition below:

```
-               &handler.EnqueueRequestForOwner{OwnerType: &eraserv1alpha1.ImageCollector{}, IsController: true}, predicate.Funcs{
+               &handler.EnqueueRequestForObject{}, predicate.Funcs{
```

The removed line can't be restored because `eraserv1alpha1.ImageCollector` was removed as a type in PR #339. Therefore, we need to manually manage ownership of these imagejobs. To accomplish this, we use an imagejob's metadata to label it. We label it by the owning controller, and then check the label as a precondition for reconciling on an ImageJob event.

Update: the `imagelist_rm_images` test has been updated to catch the respawning imagejob. The updated test is very effective at detecting the error condition. It's been tested dozens of times to ensure that it will correctly fail under the right circumstances.

Signed-off-by: Peter Engelbert <pmengelbert@gmail.com>

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #455 

**Special notes for your reviewer**:
Opening this as a draft until there's been further discussion and testing.
