### PR TITLE
ci: increase timeout for linter action

### DIFF
--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Get yarn cache
         id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" > $GITHUB_OUTPUT
 
       - name: Cache dependencies
         uses: actions/cache@v3.0.11

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ jobs:
   lint:
     name: "Lint"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 40
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@2e205a28d0e1da00c5f53b161f4067b052c61f34
@@ -74,7 +74,7 @@ jobs:
   unit-test:
     name: "Unit Tests"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@2e205a28d0e1da00c5f53b161f4067b052c61f34

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,24 +48,28 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
+          args: --timeout=5m
       - name: lint eraser
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
           working-directory: pkg/eraser
           skip-pkg-cache: true
+          args: --timeout=5m
       - name: lint collector
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
           working-directory: pkg/collector
           skip-pkg-cache: true
+          args: --timeout=5m
       - name: lint trivvy scanner
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
           working-directory: pkg/scanners/trivy
           skip-pkg-cache: true
+          args: --timeout=5m
 
   unit-test:
     name: "Unit Tests"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,28 +48,28 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
-          args: --timeout=5m
+          args: --timeout=10m
       - name: lint eraser
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
           working-directory: pkg/eraser
           skip-pkg-cache: true
-          args: --timeout=5m
+          args: --timeout=10m
       - name: lint collector
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
           working-directory: pkg/collector
           skip-pkg-cache: true
-          args: --timeout=5m
+          args: --timeout=10m
       - name: lint trivvy scanner
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
           working-directory: pkg/scanners/trivy
           skip-pkg-cache: true
-          args: --timeout=5m
+          args: --timeout=10m
 
   unit-test:
     name: "Unit Tests"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
         run: |
           readarray -d '' test_dirs < <(find ./test/e2e/tests -mindepth 1 -type d -print0)
           json_array="$(printf "%s\n" "${test_dirs[@]}" | jq -R . | jq -cs)"
-          echo "::set-output name=e2e-tests::${json_array}"
+          echo "e2e-tests=${json_array}" > $GITHUB_OUTPUT
     outputs:
       e2e-tests: ${{ steps.set-test-matrix.outputs.e2e-tests }}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The linter often times out in the ci. The default timeout is one minute which is a little short.

Signed-off-by: Peter Engelbert <pmengelbert@gmail.com>