### PR TITLE
fix: image reference logic

### DIFF
--- a/api/v1alpha1/imagejob_types.go
+++ b/api/v1alpha1/imagejob_types.go
@@ -22,8 +22,9 @@ import (
 )
 
 type Image struct {
-	Digest string `json:"digest"`
-	Name   string `json:"name,omitempty"`
+	ImageID string   `json:"image_id"`
+	Names   []string `json:"names,omitempty"`
+	Digests []string `json:"digests,omitempty"`
 }
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/pkg/collector/helpers.go
+++ b/pkg/collector/helpers.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"strings"
 
 	eraserv1alpha1 "github.com/Azure/eraser/api/v1alpha1"
 	util "github.com/Azure/eraser/pkg/utils"
@@ -16,14 +17,38 @@ func getImages(c Client) ([]eraserv1alpha1.Image, error) {
 		return nil, err
 	}
 
-	allImages := make([]string, 0, len(images))
-
-	// map with key: sha id, value: repoTag list (contains full name of image)
-	idToTagListMap := make(map[string][]string)
+	allImages := make([]eraserv1alpha1.Image, 0, len(images))
+	// map with key: imageID, value: repoTag list (contains full name of image)
+	idToImageMap := make(map[string]eraserv1alpha1.Image)
 
 	for _, img := range images {
-		allImages = append(allImages, img.Id)
-		idToTagListMap[img.Id] = img.RepoTags
+		repoTags := img.RepoTags
+		if len(repoTags) == 0 {
+			repoTags = []string{}
+		}
+
+		newImg := eraserv1alpha1.Image{
+			ImageID: img.Id,
+			Names:   repoTags,
+		}
+
+		digests := make(map[string]struct{})
+		for _, repoDigest := range img.RepoDigests {
+			s := strings.Split(repoDigest, "@")
+			if len(s) < 2 {
+				log.Info("repoDigest not formatted as image@digest", "repodigest", "repoDigest")
+				continue
+			}
+			digest := s[1]
+			digests[digest] = struct{}{}
+		}
+
+		for digest := range digests {
+			newImg.Digests = append(newImg.Digests, digest)
+		}
+
+		allImages = append(allImages, newImg)
+		idToImageMap[img.Id] = newImg
 	}
 
 	containers, err := c.listContainers(backgroundContext)
@@ -32,31 +57,31 @@ func getImages(c Client) ([]eraserv1alpha1.Image, error) {
 	}
 
 	// Images that are running
-	// map of (digest | tag) -> digest
-	runningImages := util.GetRunningImages(containers, idToTagListMap)
+	// map of (digest | name) -> imageID
+	runningImages := util.GetRunningImages(containers, idToImageMap)
 
 	// Images that aren't running
-	// map of (digest | tag) -> digest
-	nonRunningImages := util.GetNonRunningImages(runningImages, allImages, idToTagListMap)
+	// map of (digest | name) -> imageID
+	nonRunningImages := util.GetNonRunningImages(runningImages, allImages, idToImageMap)
 
 	finalImages := make([]eraserv1alpha1.Image, 0, len(images))
 
 	// empty map to keep track of repeated digest values due to both name and digest being present as keys in nonRunningImages
 	checked := make(map[string]struct{})
 
-	for _, digest := range nonRunningImages {
-		if _, exists := checked[digest]; !exists {
-			checked[digest] = struct{}{}
+	for _, imageID := range nonRunningImages {
+		if _, alreadyChecked := checked[imageID]; !alreadyChecked {
+			checked[imageID] = struct{}{}
 
+			// set the current image's digest?
+			img := idToImageMap[imageID]
 			currImage := eraserv1alpha1.Image{
-				Digest: digest,
+				ImageID: imageID,
+				Names:   img.Names,
+				Digests: img.Digests,
 			}
 
-			if len(idToTagListMap[digest]) > 0 {
-				currImage.Name = idToTagListMap[digest][0]
-			}
-
-			if !util.IsExcluded(excluded, currImage.Digest, idToTagListMap) {
+			if !util.IsExcluded(excluded, currImage.ImageID, idToImageMap) {
 				finalImages = append(finalImages, currImage)
 			}
 		}

--- a/pkg/collector/helpers.go
+++ b/pkg/collector/helpers.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"strings"
 
 	eraserv1alpha1 "github.com/Azure/eraser/api/v1alpha1"
 	util "github.com/Azure/eraser/pkg/utils"
@@ -22,30 +21,20 @@ func getImages(c Client) ([]eraserv1alpha1.Image, error) {
 	idToImageMap := make(map[string]eraserv1alpha1.Image)
 
 	for _, img := range images {
-		repoTags := img.RepoTags
-		if len(repoTags) == 0 {
-			repoTags = []string{}
-		}
+		repoTags := []string{}
+		repoTags = append(repoTags, img.RepoTags...)
 
 		newImg := eraserv1alpha1.Image{
 			ImageID: img.Id,
 			Names:   repoTags,
 		}
 
-		digests := make(map[string]struct{})
-		for _, repoDigest := range img.RepoDigests {
-			s := strings.Split(repoDigest, "@")
-			if len(s) < 2 {
-				log.Info("repoDigest not formatted as image@digest", "repodigest", "repoDigest")
-				continue
-			}
-			digest := s[1]
-			digests[digest] = struct{}{}
+		digests, errs := util.ProcessRepoDigests(img.RepoDigests)
+		for _, err := range errs {
+			log.Error(err, "error processing digest")
 		}
 
-		for digest := range digests {
-			newImg.Digests = append(newImg.Digests, digest)
-		}
+		newImg.Digests = append(newImg.Digests, digests...)
 
 		allImages = append(allImages, newImg)
 		idToImageMap[img.Id] = newImg
@@ -70,20 +59,21 @@ func getImages(c Client) ([]eraserv1alpha1.Image, error) {
 	checked := make(map[string]struct{})
 
 	for _, imageID := range nonRunningImages {
-		if _, alreadyChecked := checked[imageID]; !alreadyChecked {
-			checked[imageID] = struct{}{}
+		if _, alreadyChecked := checked[imageID]; alreadyChecked {
+			continue
+		}
 
-			// set the current image's digest?
-			img := idToImageMap[imageID]
-			currImage := eraserv1alpha1.Image{
-				ImageID: imageID,
-				Names:   img.Names,
-				Digests: img.Digests,
-			}
+		checked[imageID] = struct{}{}
+		img := idToImageMap[imageID]
 
-			if !util.IsExcluded(excluded, currImage.ImageID, idToImageMap) {
-				finalImages = append(finalImages, currImage)
-			}
+		currImage := eraserv1alpha1.Image{
+			ImageID: imageID,
+			Names:   img.Names,
+			Digests: img.Digests,
+		}
+
+		if !util.IsExcluded(excluded, currImage.ImageID, idToImageMap) {
+			finalImages = append(finalImages, currImage)
 		}
 	}
 

--- a/pkg/eraser/eraser.go
+++ b/pkg/eraser/eraser.go
@@ -109,7 +109,7 @@ func main() {
 		}
 
 		for _, img := range nonCompliantImages {
-			imagelist = append(imagelist, img.Digest)
+			imagelist = append(imagelist, img.ImageID)
 		}
 
 		log.Info("successfully created imagelist from scanned non-compliant images")

--- a/pkg/eraser/helpers.go
+++ b/pkg/eraser/helpers.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"strings"
 
+	eraserv1alpha1 "github.com/Azure/eraser/api/v1alpha1"
 	util "github.com/Azure/eraser/pkg/utils"
 )
 
@@ -17,14 +19,38 @@ func removeImages(c Client, targetImages []string) (int, error) {
 		return 0, err
 	}
 
-	allImages := make([]string, 0, len(images))
-
-	// map with key: sha id, value: repoTag list (contains full name of image)
-	idToTagListMap := make(map[string][]string)
+	allImages := make([]eraserv1alpha1.Image, 0, len(images))
+	// map with key: imageID, value: repoTag list (contains full name of image)
+	idToImageMap := make(map[string]eraserv1alpha1.Image)
 
 	for _, img := range images {
-		allImages = append(allImages, img.Id)
-		idToTagListMap[img.Id] = img.RepoTags
+		repoTags := img.RepoTags
+		if len(repoTags) == 0 {
+			repoTags = []string{}
+		}
+
+		newImg := eraserv1alpha1.Image{
+			ImageID: img.Id,
+			Names:   repoTags,
+		}
+
+		digests := make(map[string]struct{})
+		for _, repoDigest := range img.RepoDigests {
+			s := strings.Split(repoDigest, "@")
+			if len(s) < 2 {
+				log.Info("repoDigest not formatted as image@digest", "repodigest", repoDigest)
+				continue
+			}
+			digest := s[1]
+			digests[digest] = struct{}{}
+		}
+
+		for digest := range digests {
+			newImg.Digests = append(newImg.Digests, digest)
+		}
+
+		allImages = append(allImages, newImg)
+		idToImageMap[img.Id] = newImg
 	}
 
 	containers, err := c.listContainers(backgroundContext)
@@ -33,17 +59,17 @@ func removeImages(c Client, targetImages []string) (int, error) {
 	}
 
 	// Images that are running
-	// map of (digest | tag) -> digest
-	runningImages := util.GetRunningImages(containers, idToTagListMap)
+	// map of (digest | name) -> imageID
+	runningImages := util.GetRunningImages(containers, idToImageMap)
 
 	// Images that aren't running
-	// map of (digest | tag) -> digest
-	nonRunningImages := util.GetNonRunningImages(runningImages, allImages, idToTagListMap)
+	// map of (digest | name) -> imageID
+	nonRunningImages := util.GetNonRunningImages(runningImages, allImages, idToImageMap)
 
 	// Debug logs
 	log.V(1).Info("Map of non-running images", "nonRunningImages", nonRunningImages)
 	log.V(1).Info("Map of running images", "runningImages", runningImages)
-	log.V(1).Info("Map of digest to image name(s)", "idToTaglistMap", idToTagListMap)
+	log.V(1).Info("Map of digest to image name(s)", "idToImageMap", idToImageMap)
 
 	// remove target images
 	var prune bool
@@ -54,27 +80,27 @@ func removeImages(c Client, targetImages []string) (int, error) {
 			continue
 		}
 
-		if digest, isNonRunning := nonRunningImages[imgDigestOrTag]; isNonRunning {
-			if ex := util.IsExcluded(excluded, imgDigestOrTag, idToTagListMap); ex {
-				log.Info("image is excluded", "given", imgDigestOrTag, "digest", digest, "name", idToTagListMap[digest])
+		if imageID, isNonRunning := nonRunningImages[imgDigestOrTag]; isNonRunning {
+			if ex := util.IsExcluded(excluded, imgDigestOrTag, idToImageMap); ex {
+				log.Info("image is excluded", "given", imgDigestOrTag, "imageID", imageID)
 				continue
 			}
 
-			err = c.deleteImage(backgroundContext, digest)
+			err = c.deleteImage(backgroundContext, imageID)
 			if err != nil {
-				log.Error(err, "error removing image", "given", imgDigestOrTag, "digest", digest, "name", idToTagListMap[digest])
+				log.Error(err, "error removing image", "given", imgDigestOrTag, "imageID", imageID)
 				continue
 			}
 
 			deletedImages[imgDigestOrTag] = struct{}{}
-			log.Info("removed image", "given", imgDigestOrTag, "digest", digest, "name", idToTagListMap[digest])
+			log.Info("removed image", "given", imgDigestOrTag, "imageID", imageID)
 			removed++
 			continue
 		}
 
-		digest, isRunning := runningImages[imgDigestOrTag]
+		imageID, isRunning := runningImages[imgDigestOrTag]
 		if isRunning {
-			log.Info("image is running", "given", imgDigestOrTag, "digest", digest, "name", idToTagListMap[digest])
+			log.Info("image is running", "given", imgDigestOrTag, "imageID", imageID, "name", idToImageMap[imageID])
 			continue
 		}
 
@@ -83,23 +109,24 @@ func removeImages(c Client, targetImages []string) (int, error) {
 
 	if prune {
 		success := true
-		for _, digest := range nonRunningImages {
-			if _, deleted := deletedImages[digest]; deleted {
+		for _, imageID := range nonRunningImages {
+			if _, deleted := deletedImages[imageID]; deleted {
 				continue
 			}
 
-			if util.IsExcluded(excluded, digest, idToTagListMap) {
-				log.Info("image is excluded", "digest", digest, "name", idToTagListMap[digest])
+			if util.IsExcluded(excluded, imageID, idToImageMap) {
+				log.Info("image is excluded", "imageID", imageID)
 				continue
 			}
 
-			if err := c.deleteImage(backgroundContext, digest); err != nil {
+			if err := c.deleteImage(backgroundContext, imageID); err != nil {
 				success = false
-				log.Error(err, "error removing image", "digest", digest, "name", idToTagListMap[digest])
+				log.Error(err, "error removing image", "imageID", imageID)
 				continue
 			}
-			log.Info("removed image", "digest", digest, "name", idToTagListMap[digest])
-			deletedImages[digest] = struct{}{}
+
+			log.Info("removed image", "digest", imageID)
+			deletedImages[imageID] = struct{}{}
 			removed++
 		}
 		if success {

--- a/pkg/scanners/trivy/trivy.go
+++ b/pkg/scanners/trivy/trivy.go
@@ -183,61 +183,72 @@ func main() {
 	failedImages := make([]eraserv1alpha1.Image, 0, len(allImages))
 
 	for _, img := range allImages {
-		imageRef := img.Name
-		if imageRef == "" {
+		refs := make([]string, 0, len(img.Names)+len(img.Digests)+1)
+		refs = append(refs, img.Digests...)
+		refs = append(refs, img.Names...)
+
+		if len(refs) == 0 {
 			log.Info("found image with no name", "img", img)
 			failedImages = append(failedImages, img)
 			continue
 		}
 
-		log.Info("scanning image", "imageRef", imageRef)
+		imageScanFailed := true
+		log.Info("scanning image with id", "imageRef", img.ImageID, "refs", refs)
 
-		dockerImage, cleanup, err := fanalImage.NewDockerImage(ctx, imageRef, scanConfig.dockerOptions)
-		if err != nil {
-			log.Error(err, "error fetching manifest for image", "img", img)
-			failedImages = append(failedImages, img)
-			cleanup()
-			continue
-		}
+		for i := 0; i < len(refs) && imageScanFailed; i++ {
+			ref := refs[i]
 
-		artifactToScan, err := artifactImage.NewArtifact(dockerImage, scanConfig.fscache, artifact.Option{})
-		if err != nil {
-			log.Error(err, "error registering config for artifact", "img", img)
-			failedImages = append(failedImages, img)
-			cleanup()
-			continue
-		}
+			dockerImage, cleanup, err := fanalImage.NewDockerImage(ctx, ref, scanConfig.dockerOptions)
+			if err != nil { // could not locate image
+				log.Error(err, "could not find image by reference", "img", img, "reference", ref)
+				cleanup()
+				continue
+			}
 
-		scanner := scanner.NewScanner(scanConfig.localScanner, artifactToScan)
-		report, err := scanner.ScanArtifact(ctx, scanConfig.scanOptions)
-		if err != nil {
-			log.Error(err, "error scanning image", "img", img)
-			failedImages = append(failedImages, img)
-			cleanup()
-			continue
-		}
+			artifactToScan, err := artifactImage.NewArtifact(dockerImage, scanConfig.fscache, artifact.Option{})
+			if err != nil {
+				log.Error(err, "error registering config for artifact", "img", img, "reference", ref)
+				cleanup()
+				continue
+			}
 
-	outer:
-		for i := range report.Results {
-			resultClient.FillVulnerabilityInfo(report.Results[i].Vulnerabilities, report.Results[i].Type)
+			scanner := scanner.NewScanner(scanConfig.localScanner, artifactToScan)
+			report, err := scanner.ScanArtifact(ctx, scanConfig.scanOptions)
+			if err != nil {
+				log.Error(err, "error scanning image", "img", img, "reference", ref)
+				cleanup()
+				continue
+			}
 
-			for j := range report.Results[i].Vulnerabilities {
-				if *ignoreUnfixed && report.Results[i].Vulnerabilities[j].FixedVersion == "" {
-					continue
-				}
+			imageScanFailed = false
 
-				if report.Results[i].Vulnerabilities[j].Severity == "" {
-					report.Results[i].Vulnerabilities[j].Severity = severityUnknown
-				}
+		outer:
+			for i := range report.Results {
+				resultClient.FillVulnerabilityInfo(report.Results[i].Vulnerabilities, report.Results[i].Type)
 
-				if severityMap[report.Results[i].Vulnerabilities[j].Severity] {
-					vulnerableImages = append(vulnerableImages, img)
-					break outer
+				for j := range report.Results[i].Vulnerabilities {
+					if *ignoreUnfixed && report.Results[i].Vulnerabilities[j].FixedVersion == "" {
+						continue
+					}
+
+					if report.Results[i].Vulnerabilities[j].Severity == "" {
+						report.Results[i].Vulnerabilities[j].Severity = severityUnknown
+					}
+
+					if severityMap[report.Results[i].Vulnerabilities[j].Severity] {
+						vulnerableImages = append(vulnerableImages, img)
+						break outer
+					}
 				}
 			}
+
+			cleanup()
 		}
 
-		cleanup()
+		if imageScanFailed {
+			failedImages = append(failedImages, img)
+		}
 	}
 
 	if len(failedImages) > 0 {

--- a/pkg/scanners/trivy/trivy.go
+++ b/pkg/scanners/trivy/trivy.go
@@ -183,7 +183,7 @@ func main() {
 	failedImages := make([]eraserv1alpha1.Image, 0, len(allImages))
 
 	for _, img := range allImages {
-		refs := make([]string, 0, len(img.Names)+len(img.Digests)+1)
+		refs := make([]string, 0, len(img.Names)+len(img.Digests))
 		refs = append(refs, img.Digests...)
 		refs = append(refs, img.Names...)
 
@@ -194,21 +194,22 @@ func main() {
 		}
 
 		imageScanFailed := true
-		log.Info("scanning image with id", "imageRef", img.ImageID, "refs", refs)
+		log.Info("scanning image with id", "imageID", img.ImageID, "refs", refs)
 
 		for i := 0; i < len(refs) && imageScanFailed; i++ {
 			ref := refs[i]
+			log.Info("scanning image with ref", "ref", ref)
 
 			dockerImage, cleanup, err := fanalImage.NewDockerImage(ctx, ref, scanConfig.dockerOptions)
 			if err != nil { // could not locate image
-				log.Error(err, "could not find image by reference", "img", img, "reference", ref)
+				log.Error(err, "could not find image by reference", "imageID", img.ImageID, "reference", ref)
 				cleanup()
 				continue
 			}
 
 			artifactToScan, err := artifactImage.NewArtifact(dockerImage, scanConfig.fscache, artifact.Option{})
 			if err != nil {
-				log.Error(err, "error registering config for artifact", "img", img, "reference", ref)
+				log.Error(err, "error registering config for artifact", "imageID", img.ImageID, "reference", ref)
 				cleanup()
 				continue
 			}
@@ -216,7 +217,7 @@ func main() {
 			scanner := scanner.NewScanner(scanConfig.localScanner, artifactToScan)
 			report, err := scanner.ScanArtifact(ctx, scanConfig.scanOptions)
 			if err != nil {
-				log.Error(err, "error scanning image", "img", img, "reference", ref)
+				log.Error(err, "error scanning image", "imageID", img.ImageID, "reference", ref)
 				cleanup()
 				continue
 			}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -116,6 +116,23 @@ func ListImages(ctx context.Context, images pb.ImageServiceClient) (list []*pb.I
 		return nil, err
 	}
 
+	for _, img := range resp.Images {
+		ximg := pb.ImageSpec{Image: img.Id}
+		req := pb.ImageStatusRequest{
+			Image:   &ximg,
+			Verbose: true,
+		}
+
+		resp, err := images.ImageStatus(ctx, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		fmt.Printf(`{ "IMAGE": "%#v",
+            "INFO": "%#v }"`, resp.Image, resp.Info)
+		_ = img
+	}
+
 	return resp.Images, nil
 }
 
@@ -127,33 +144,42 @@ func ListContainers(ctx context.Context, runtime pb.RuntimeServiceClient) (list 
 	return resp.Containers, nil
 }
 
-func GetRunningImages(containers []*pb.Container, idToTagListMap map[string][]string) map[string]string {
+func GetRunningImages(containers []*pb.Container, idToImageMap map[string]eraserv1alpha1.Image) map[string]string {
 	// Images that are running
 	// map of (digest | tag) -> digest
 	runningImages := make(map[string]string)
 	for _, container := range containers {
 		curr := container.Image
-		digest := curr.GetImage()
-		runningImages[digest] = digest
+		imageID := curr.GetImage()
+		runningImages[imageID] = imageID
 
-		for _, tag := range idToTagListMap[digest] {
-			runningImages[tag] = digest
+		for _, name := range idToImageMap[imageID].Names {
+			runningImages[name] = imageID
+		}
+
+		for _, digest := range idToImageMap[imageID].Digests {
+			runningImages[digest] = imageID
 		}
 	}
 	return runningImages
 }
 
-func GetNonRunningImages(runningImages map[string]string, allImages []string, idToTagListMap map[string][]string) map[string]string {
+func GetNonRunningImages(runningImages map[string]string, allImages []eraserv1alpha1.Image, idToImageMap map[string]eraserv1alpha1.Image) map[string]string {
 	// Images that aren't running
 	// map of (digest | tag) -> digest
 	nonRunningImages := make(map[string]string)
 
-	for _, digest := range allImages {
-		if _, isRunning := runningImages[digest]; !isRunning {
-			nonRunningImages[digest] = digest
+	for _, img := range allImages {
+		imageID := img.ImageID
+		if _, isRunning := runningImages[imageID]; !isRunning {
+			nonRunningImages[imageID] = imageID
 
-			for _, tag := range idToTagListMap[digest] {
-				nonRunningImages[tag] = digest
+			for _, name := range idToImageMap[imageID].Names {
+				nonRunningImages[name] = imageID
+			}
+
+			for _, digest := range idToImageMap[imageID].Digests {
+				nonRunningImages[digest] = imageID
 			}
 		}
 	}
@@ -161,7 +187,7 @@ func GetNonRunningImages(runningImages map[string]string, allImages []string, id
 	return nonRunningImages
 }
 
-func IsExcluded(excluded map[string]struct{}, img string, idToTagListMap map[string][]string) bool {
+func IsExcluded(excluded map[string]struct{}, img string, idToImageMap map[string]eraserv1alpha1.Image) bool {
 	if len(excluded) == 0 {
 		return false
 	}
@@ -172,8 +198,14 @@ func IsExcluded(excluded map[string]struct{}, img string, idToTagListMap map[str
 	}
 
 	// check if img excluded by name
-	for _, imgName := range idToTagListMap[img] {
+	for _, imgName := range idToImageMap[img].Names {
 		if _, contains := excluded[imgName]; contains {
+			return true
+		}
+	}
+
+	for _, digest := range idToImageMap[img].Digests {
+		if _, contains := excluded[digest]; contains {
 			return true
 		}
 	}
@@ -191,8 +223,14 @@ func IsExcluded(excluded map[string]struct{}, img string, idToTagListMap map[str
 			}
 
 			// retrieve and check by name in the case img is digest
-			for _, imgName := range idToTagListMap[img] {
+			for _, imgName := range idToImageMap[img].Names {
 				if match := strings.HasPrefix(imgName, repo[0]); match {
+					return true
+				}
+			}
+
+			for _, digest := range idToImageMap[img].Digests {
+				if match := strings.HasPrefix(digest, repo[0]); match {
 					return true
 				}
 			}
@@ -208,8 +246,14 @@ func IsExcluded(excluded map[string]struct{}, img string, idToTagListMap map[str
 			}
 
 			// retrieve and check by name in the case img is digest
-			for _, imgName := range idToTagListMap[img] {
+			for _, imgName := range idToImageMap[img].Names {
 				if match := strings.HasPrefix(imgName, imagePath[0]); match {
+					return true
+				}
+			}
+
+			for _, digest := range idToImageMap[img].Digests {
+				if match := strings.HasPrefix(digest, imagePath[0]); match {
 					return true
 				}
 			}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -404,3 +404,25 @@ func WriteScanErasePipe(vulnerableImages []eraserv1alpha1.Image) error {
 
 	return file.Close()
 }
+
+func ProcessRepoDigests(repoDigests []string) ([]string, []error) {
+	digests := []string{}
+	errs := []error{}
+
+	digestSet := make(map[string]struct{})
+	for _, repoDigest := range repoDigests {
+		s := strings.Split(repoDigest, "@")
+		if len(s) < 2 {
+			errs = append(errs, fmt.Errorf("repoDigest not formatted correctly: %s", repoDigest))
+			continue
+		}
+		digest := s[1]
+		digestSet[digest] = struct{}{}
+	}
+
+	for digest := range digestSet {
+		digests = append(digests, digest)
+	}
+
+	return digests, errs
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -116,23 +116,6 @@ func ListImages(ctx context.Context, images pb.ImageServiceClient) (list []*pb.I
 		return nil, err
 	}
 
-	for _, img := range resp.Images {
-		ximg := pb.ImageSpec{Image: img.Id}
-		req := pb.ImageStatusRequest{
-			Image:   &ximg,
-			Verbose: true,
-		}
-
-		resp, err := images.ImageStatus(ctx, &req)
-		if err != nil {
-			return nil, err
-		}
-
-		fmt.Printf(`{ "IMAGE": "%#v",
-            "INFO": "%#v }"`, resp.Image, resp.Info)
-		_ = img
-	}
-
 	return resp.Images, nil
 }
 


### PR DESCRIPTION
Resolves #469 by preserving imageID, digest, and name information from images throughout the collect->scan->erase pipeline.