### PR TITLE
fix: collector skip excluded test

### DIFF
--- a/test/e2e/tests/collector_skip_excluded/eraser_test.go
+++ b/test/e2e/tests/collector_skip_excluded/eraser_test.go
@@ -40,6 +40,11 @@ func TestCollectorExcluded(t *testing.T) {
 				if err != nil {
 					t.Error("collector pod unsuccessful", err, pod.Name)
 				}
+				output, err = KubectlLogs(cfg.KubeconfigFile(), pod.Name, "collector", util.EraserNamespace)
+				if err != nil {
+					t.Errorf("could not get collector container logs %s %v", pod.Name, err)
+				}
+				t.Log("OUTPUT", output)
 			}
 
 			return ctx

--- a/test/e2e/tests/collector_skip_excluded/eraser_test.go
+++ b/test/e2e/tests/collector_skip_excluded/eraser_test.go
@@ -38,42 +38,42 @@ func TestCollectorExcluded(t *testing.T) {
 			for _, pod := range ls.Items {
 				err = wait.For(conditions.New(c.Resources()).PodPhaseMatch(&pod, corev1.PodSucceeded), wait.WithTimeout(time.Minute*3))
 				if err != nil {
-					t.Error("collector pod unsuccessful", err, pod.Name)
+					t.Log("collector pod unsuccessful", pod.Name)
 				}
 				output, err := util.KubectlLogs(cfg.KubeconfigFile(), pod.Name, "collector", util.EraserNamespace)
 				if err != nil {
-					t.Errorf("could not get collector container logs %s %v", pod.Name, err)
+					t.Log("could not get collector container logs %s", pod.Name)
 				}
 				t.Log("OUTPUT", output)
 			}
 
 			return ctx
 		}).
-		Assess("Alpine image is not removed", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			ctxT, cancel := context.WithTimeout(ctx, time.Minute*5)
-			defer cancel()
-			util.CheckImagesExist(ctxT, t, util.GetClusterNodes(t), util.VulnerableImage)
+		/*	Assess("Alpine image is not removed", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				ctxT, cancel := context.WithTimeout(ctx, time.Minute*5)
+				defer cancel()
+				util.CheckImagesExist(ctxT, t, util.GetClusterNodes(t), util.VulnerableImage)
 
-			return ctx
-		}).
-		Assess("Non-vulnerable image is not removed", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			ctxT, cancel := context.WithTimeout(ctx, time.Minute*5)
-			defer cancel()
-			util.CheckImagesExist(ctxT, t, util.GetClusterNodes(t), util.NonVulnerableImage)
+				return ctx
+			}).
+			Assess("Non-vulnerable image is not removed", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				ctxT, cancel := context.WithTimeout(ctx, time.Minute*5)
+				defer cancel()
+				util.CheckImagesExist(ctxT, t, util.GetClusterNodes(t), util.NonVulnerableImage)
 
-			return ctx
-		}).
-		Assess("Get logs", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			if err := util.GetPodLogs(ctx, cfg, t, false); err != nil {
-				t.Error("error getting collector pod logs", err)
-			}
+				return ctx
+			}).
+			Assess("Get logs", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				if err := util.GetPodLogs(ctx, cfg, t, false); err != nil {
+					t.Error("error getting collector pod logs", err)
+				}
 
-			if err := util.GetManagerLogs(ctx, cfg, t); err != nil {
-				t.Error("error getting manager logs", err)
-			}
+				if err := util.GetManagerLogs(ctx, cfg, t); err != nil {
+					t.Error("error getting manager logs", err)
+				}
 
-			return ctx
-		}).
+				return ctx
+			}).*/
 		Feature()
 
 	util.Testenv.Test(t, collectorExcluded)

--- a/test/e2e/tests/collector_skip_excluded/eraser_test.go
+++ b/test/e2e/tests/collector_skip_excluded/eraser_test.go
@@ -44,7 +44,19 @@ func TestCollectorExcluded(t *testing.T) {
 				if err != nil {
 					t.Log("could not get collector container logs", pod.Name)
 				}
-				t.Log("OUTPUT", output)
+				t.Log("OUTPUT collector", output)
+
+				output, err = util.KubectlLogs(cfg.KubeconfigFile(), pod.Name, "trivy-scanner", util.EraserNamespace)
+				if err != nil {
+					t.Log("could not get collector container logs", pod.Name)
+				}
+				t.Log("OUTPUT scanner", output)
+
+				output, err = util.KubectlLogs(cfg.KubeconfigFile(), pod.Name, "eraser", util.EraserNamespace)
+				if err != nil {
+					t.Log("could not get collector container logs", pod.Name)
+				}
+				t.Log("OUTPUT eraser", output)
 			}
 
 			return ctx

--- a/test/e2e/tests/collector_skip_excluded/eraser_test.go
+++ b/test/e2e/tests/collector_skip_excluded/eraser_test.go
@@ -40,52 +40,35 @@ func TestCollectorExcluded(t *testing.T) {
 				if err != nil {
 					t.Log("collector pod unsuccessful", pod.Name)
 				}
-				output, err := util.KubectlLogs(cfg.KubeconfigFile(), pod.Name, "collector", util.EraserNamespace)
-				if err != nil {
-					t.Log("could not get collector container logs", pod.Name)
-				}
-				t.Log("OUTPUT collector", output)
-
-				output, err = util.KubectlLogs(cfg.KubeconfigFile(), pod.Name, "trivy-scanner", util.EraserNamespace)
-				if err != nil {
-					t.Log("could not get collector container logs", pod.Name)
-				}
-				t.Log("OUTPUT scanner", output)
-
-				output, err = util.KubectlLogs(cfg.KubeconfigFile(), pod.Name, "eraser", util.EraserNamespace)
-				if err != nil {
-					t.Log("could not get collector container logs", pod.Name)
-				}
-				t.Log("OUTPUT eraser", output)
 			}
 
 			return ctx
 		}).
-		/*	Assess("Alpine image is not removed", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-				ctxT, cancel := context.WithTimeout(ctx, time.Minute*5)
-				defer cancel()
-				util.CheckImagesExist(ctxT, t, util.GetClusterNodes(t), util.VulnerableImage)
+		Assess("Alpine image is not removed", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ctxT, cancel := context.WithTimeout(ctx, time.Minute*5)
+			defer cancel()
+			util.CheckImagesExist(ctxT, t, util.GetClusterNodes(t), util.VulnerableImage)
 
-				return ctx
-			}).
-			Assess("Non-vulnerable image is not removed", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-				ctxT, cancel := context.WithTimeout(ctx, time.Minute*5)
-				defer cancel()
-				util.CheckImagesExist(ctxT, t, util.GetClusterNodes(t), util.NonVulnerableImage)
+			return ctx
+		}).
+		Assess("Non-vulnerable image is not removed", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ctxT, cancel := context.WithTimeout(ctx, time.Minute*5)
+			defer cancel()
+			util.CheckImagesExist(ctxT, t, util.GetClusterNodes(t), util.NonVulnerableImage)
 
-				return ctx
-			}).
-			Assess("Get logs", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-				if err := util.GetPodLogs(ctx, cfg, t, false); err != nil {
-					t.Error("error getting collector pod logs", err)
-				}
+			return ctx
+		}).
+		Assess("Get logs", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			if err := util.GetPodLogs(ctx, cfg, t, false); err != nil {
+				t.Error("error getting collector pod logs", err)
+			}
 
-				if err := util.GetManagerLogs(ctx, cfg, t); err != nil {
-					t.Error("error getting manager logs", err)
-				}
+			if err := util.GetManagerLogs(ctx, cfg, t); err != nil {
+				t.Error("error getting manager logs", err)
+			}
 
-				return ctx
-			}).*/
+			return ctx
+		}).
 		Feature()
 
 	util.Testenv.Test(t, collectorExcluded)

--- a/test/e2e/tests/collector_skip_excluded/eraser_test.go
+++ b/test/e2e/tests/collector_skip_excluded/eraser_test.go
@@ -40,7 +40,7 @@ func TestCollectorExcluded(t *testing.T) {
 				if err != nil {
 					t.Error("collector pod unsuccessful", err, pod.Name)
 				}
-				output, err = KubectlLogs(cfg.KubeconfigFile(), pod.Name, "collector", util.EraserNamespace)
+				output, err := util.KubectlLogs(cfg.KubeconfigFile(), pod.Name, "collector", util.EraserNamespace)
 				if err != nil {
 					t.Errorf("could not get collector container logs %s %v", pod.Name, err)
 				}

--- a/test/e2e/tests/collector_skip_excluded/eraser_test.go
+++ b/test/e2e/tests/collector_skip_excluded/eraser_test.go
@@ -10,12 +10,40 @@ import (
 
 	"github.com/Azure/eraser/test/e2e/util"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
 func TestCollectorExcluded(t *testing.T) {
 	collectorExcluded := features.New("ImageCollector should not remove excluded images").
+		Assess("Collector pods completed", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			c, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal("Failed to create new client", err)
+			}
+
+			var ls corev1.PodList
+			err = c.Resources().List(ctx, &ls, func(o *metav1.ListOptions) {
+				o.LabelSelector = labels.SelectorFromSet(map[string]string{"name": "collector"}).String()
+			})
+			if err != nil {
+				t.Errorf("could not list pods: %v", err)
+			}
+
+			for _, pod := range ls.Items {
+				err = wait.For(conditions.New(c.Resources()).PodPhaseMatch(&pod, corev1.PodSucceeded), wait.WithTimeout(time.Minute*3))
+				if err != nil {
+					t.Error("collector pod unsuccessful", err, pod.Name)
+				}
+			}
+
+			return ctx
+		}).
 		Assess("Alpine image is not removed", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			ctxT, cancel := context.WithTimeout(ctx, time.Minute*5)
 			defer cancel()

--- a/test/e2e/tests/collector_skip_excluded/eraser_test.go
+++ b/test/e2e/tests/collector_skip_excluded/eraser_test.go
@@ -42,7 +42,7 @@ func TestCollectorExcluded(t *testing.T) {
 				}
 				output, err := util.KubectlLogs(cfg.KubeconfigFile(), pod.Name, "collector", util.EraserNamespace)
 				if err != nil {
-					t.Log("could not get collector container logs %s", pod.Name)
+					t.Log("could not get collector container logs", pod.Name)
 				}
 				t.Log("OUTPUT", output)
 			}

--- a/test/e2e/tests/collector_skip_excluded/main_test.go
+++ b/test/e2e/tests/collector_skip_excluded/main_test.go
@@ -14,8 +14,6 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
-
-	pkgUtil "github.com/Azure/eraser/pkg/utils"
 )
 
 func TestMain(m *testing.M) {
@@ -24,6 +22,7 @@ func TestMain(m *testing.M) {
 	eraserImage := util.ParsedImages.EraserImage
 	managerImage := util.ParsedImages.ManagerImage
 	collectorImage := util.ParsedImages.CollectorImage
+	scannerImage := util.ParsedImages.ScannerImage
 
 	util.Testenv = env.NewWithConfig(envconf.New())
 	// Create KinD Cluster
@@ -36,21 +35,18 @@ func TestMain(m *testing.M) {
 		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.CollectorImage),
 		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.VulnerableImage),
 		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.NonVulnerableImage),
-		util.CreateExclusionList(util.EraserNamespace, pkgUtil.ExclusionList{
-			Excluded: []string{"docker.io/library/alpine:*"},
-		}),
-		util.CreateExclusionList(util.EraserNamespace, pkgUtil.ExclusionList{
-			Excluded: []string{util.NonVulnerableImage},
-		}),
+		util.CreateExclusionList(util.EraserNamespace, "{\"excluded\": [\"docker.io/library/alpine:*\"]}"),
+		util.CreateExclusionList(util.EraserNamespace, "{\"excluded\": [\""+util.NonVulnerableImage+"\"]}"),
 		util.DeployEraserHelm(util.EraserNamespace,
-			"--set", util.ScannerImageRepo.Set(""),
+			"--set", util.ScannerImageRepo.Set(scannerImage.Repo),
+			"--set", util.ScannerImageTag.Set(scannerImage.Tag),
 			"--set", util.EraserImageRepo.Set(eraserImage.Repo),
 			"--set", util.EraserImageTag.Set(eraserImage.Tag),
 			"--set", util.CollectorImageRepo.Set(collectorImage.Repo),
 			"--set", util.CollectorImageTag.Set(collectorImage.Tag),
 			"--set", util.ManagerImageRepo.Set(managerImage.Repo),
 			"--set", util.ManagerImageTag.Set(managerImage.Tag),
-			"--set", `controllerManager.additionalArgs={--job-cleanup-on-success-delay=1m}`),
+			"--set", `controllerManager.additionalArgs={--job-cleanup-on-success-delay=2m}`),
 	).Finish(
 		envfuncs.DestroyKindCluster(util.KindClusterName),
 	)

--- a/test/e2e/tests/collector_skip_excluded/main_test.go
+++ b/test/e2e/tests/collector_skip_excluded/main_test.go
@@ -35,6 +35,7 @@ func TestMain(m *testing.M) {
 		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.CollectorImage),
 		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.VulnerableImage),
 		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.NonVulnerableImage),
+		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.ScannerImage),
 		util.CreateExclusionList(util.EraserNamespace, "{\"excluded\": [\"docker.io/library/alpine:*\"]}"),
 		util.CreateExclusionList(util.EraserNamespace, "{\"excluded\": [\""+util.NonVulnerableImage+"\"]}"),
 		util.DeployEraserHelm(util.EraserNamespace,

--- a/test/e2e/util/utils.go
+++ b/test/e2e/util/utils.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -764,14 +763,9 @@ func DeployEraserManifest(namespace, fileName string) env.Func {
 	}
 }
 
-func CreateExclusionList(namespace string, list pkgUtil.ExclusionList) env.Func {
+func CreateExclusionList(namespace string, list string) env.Func {
 	return func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
 		c, err := cfg.NewClient()
-		if err != nil {
-			return ctx, err
-		}
-
-		b, err := json.Marshal(&list)
 		if err != nil {
 			return ctx, err
 		}
@@ -781,8 +775,9 @@ func CreateExclusionList(namespace string, list pkgUtil.ExclusionList) env.Func 
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "excluded",
 				Namespace:    EraserNamespace,
+				Labels:       map[string]string{"eraser.sh/exclude.list": "true"},
 			},
-			Data: map[string]string{"excluded": string(b)},
+			Data: map[string]string{"excluded.json": list},
 		}
 		if err := cfg.Client().Resources().Create(ctx, &excluded); err != nil {
 			return ctx, err


### PR DESCRIPTION
**What this PR does / why we need it**:
Collector skip excluded test was not correctly parsing exclusion list. PR fixes creation of exclusion list and waits for collector pods to finish before checking that excluded images were not removed.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
