### PR TITLE
feat: pull secret

### DIFF
--- a/controllers/imagejob/imagejob_controller.go
+++ b/controllers/imagejob/imagejob_controller.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -465,6 +466,13 @@ func copyAndFillTemplateSpec(templateSpecTemplate *corev1.PodSpec, env []corev1.
 		scannerImg := &templateSpec.Containers[2]
 		scannerImg.VolumeMounts = append(scannerImg.VolumeMounts, volumeMounts...)
 		scannerImg.Env = append(scannerImg.Env, env...)
+	}
+
+	secret := os.Getenv("ERASER_PULL_SECRET_NAME")
+	if secret != "" {
+		templateSpec.ImagePullSecrets = []corev1.LocalObjectReference{{
+			Name: secret,
+		}}
 	}
 
 	templateSpec.Volumes = append(volumes, templateSpec.Volumes...)

--- a/controllers/imagejob/imagejob_controller.go
+++ b/controllers/imagejob/imagejob_controller.go
@@ -468,11 +468,13 @@ func copyAndFillTemplateSpec(templateSpecTemplate *corev1.PodSpec, env []corev1.
 		scannerImg.Env = append(scannerImg.Env, env...)
 	}
 
-	secret := os.Getenv("ERASER_PULL_SECRET_NAME")
-	if secret != "" {
-		templateSpec.ImagePullSecrets = []corev1.LocalObjectReference{{
-			Name: secret,
-		}}
+	secrets := os.Getenv("ERASER_PULL_SECRET_NAMES")
+	if secrets != "" {
+		for _, secret := range strings.Split(secrets, ",") {
+			templateSpec.ImagePullSecrets = []corev1.LocalObjectReference{{
+				Name: secret,
+			}}
+		}
 	}
 
 	templateSpec.Volumes = append(volumes, templateSpec.Volumes...)

--- a/manifest_staging/charts/eraser/templates/eraser-controller-manager-deployment.yaml
+++ b/manifest_staging/charts/eraser/templates/eraser-controller-manager-deployment.yaml
@@ -27,9 +27,9 @@ spec:
         control-plane: controller-manager
         helm.sh/chart: '{{ template "eraser.name" . }}'
     spec:
-      {{- if .Values.eraserPullSecretName }}
+      {{- if .Values.eraserPullSecrets }}
       imagePullSecrets:
-        - name: "{{ .Values.eraserPullSecretName }}"
+        {{- toYaml .Values.eraserPullSecrets | nindent 8 }}
       {{- end }}
       affinity:
         {{- toYaml .Values.controllerManager.affinity | nindent 8 }}
@@ -46,8 +46,8 @@ spec:
         command:
         - /manager
         env:
-        - name: ERASER_PULL_SECRET_NAME
-          value: '{{ .Values.eraserPullSecretName }}'
+        - name: ERASER_PULL_SECRET_NAMES
+          value: "{{- range $i, $e := .Values.eraserPullSecrets -}}{{- range $k, $v := $e }}{{- if $i -}},{{- end -}}{{- $v -}}{{- end -}}{{- end }}"
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/manifest_staging/charts/eraser/templates/eraser-controller-manager-deployment.yaml
+++ b/manifest_staging/charts/eraser/templates/eraser-controller-manager-deployment.yaml
@@ -27,6 +27,10 @@ spec:
         control-plane: controller-manager
         helm.sh/chart: '{{ template "eraser.name" . }}'
     spec:
+      {{- if .Values.eraserPullSecretName }}
+      imagePullSecrets:
+        - name: "{{ .Values.eraserPullSecretName }}"
+      {{- end }}
       affinity:
         {{- toYaml .Values.controllerManager.affinity | nindent 8 }}
       containers:
@@ -42,6 +46,8 @@ spec:
         command:
         - /manager
         env:
+        - name: ERASER_PULL_SECRET_NAME
+          value: '{{ .Values.eraserPullSecretName }}'
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/manifest_staging/charts/eraser/templates/eraser-controller-manager-deployment.yaml
+++ b/manifest_staging/charts/eraser/templates/eraser-controller-manager-deployment.yaml
@@ -27,9 +27,9 @@ spec:
         control-plane: controller-manager
         helm.sh/chart: '{{ template "eraser.name" . }}'
     spec:
-      {{- if .Values.eraserPullSecrets }}
+      {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml .Values.eraserPullSecrets | nindent 8 }}
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       {{- end }}
       affinity:
         {{- toYaml .Values.controllerManager.affinity | nindent 8 }}
@@ -47,7 +47,7 @@ spec:
         - /manager
         env:
         - name: ERASER_PULL_SECRET_NAMES
-          value: "{{- range $i, $e := .Values.eraserPullSecrets -}}{{- range $k, $v := $e }}{{- if $i -}},{{- end -}}{{- $v -}}{{- end -}}{{- end }}"
+          value: "{{- range $i, $e := .Values.imagePullSecrets -}}{{- range $k, $v := $e }}{{- if $i -}},{{- end -}}{{- $v -}}{{- end -}}{{- end }}"
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/manifest_staging/charts/eraser/values.yaml
+++ b/manifest_staging/charts/eraser/values.yaml
@@ -43,3 +43,4 @@ scanner:
     args: []
 
 nameOverride: ""
+eraserPullSecretName: ""

--- a/manifest_staging/charts/eraser/values.yaml
+++ b/manifest_staging/charts/eraser/values.yaml
@@ -43,4 +43,4 @@ scanner:
     args: []
 
 nameOverride: ""
-eraserPullSecretName: ""
+eraserPullSecrets: []

--- a/manifest_staging/charts/eraser/values.yaml
+++ b/manifest_staging/charts/eraser/values.yaml
@@ -43,4 +43,4 @@ scanner:
     args: []
 
 nameOverride: ""
-eraserPullSecrets: []
+imagePullSecrets: []

--- a/test/e2e/test-data/helm-empty-values.yaml
+++ b/test/e2e/test-data/helm-empty-values.yaml
@@ -57,4 +57,4 @@ scanner:
     args: []
 
 nameOverride: ""
-eraserPullSecretName: ""
+imagePullSecretName: ""

--- a/test/e2e/test-data/helm-empty-values.yaml
+++ b/test/e2e/test-data/helm-empty-values.yaml
@@ -57,3 +57,4 @@ scanner:
     args: []
 
 nameOverride: ""
+eraserPullSecretName: ""

--- a/test/e2e/tests/helm_pull_secret/eraser_test.go
+++ b/test/e2e/tests/helm_pull_secret/eraser_test.go
@@ -1,0 +1,90 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Azure/eraser/test/e2e/util"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+const (
+	collectorLabel = "name=collector"
+)
+
+func TestCollectorExcluded(t *testing.T) {
+	pullSecretsPropagated := features.New("Collector pods completed").
+		Assess("All pods should have the correct pull secret", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			c, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal("Failed to create new client", err)
+			}
+
+			err = wait.For(
+				util.NumPodsPresentForLabel(ctx, c, 3, collectorLabel),
+				wait.WithTimeout(time.Minute*2),
+				wait.WithInterval(time.Millisecond*500),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var ls corev1.PodList
+			err = c.Resources().List(ctx, &ls, func(o *metav1.ListOptions) {
+				o.LabelSelector = labels.SelectorFromSet(map[string]string{"name": "collector"}).String()
+			})
+			if err != nil {
+				t.Errorf("could not list pods: %v", err)
+			}
+
+			var ls2 corev1.PodList
+			err = c.Resources().List(ctx, &ls2, func(o *metav1.ListOptions) {
+				o.LabelSelector = labels.SelectorFromSet(map[string]string{"control-plane": "controller-manager"}).String()
+			})
+
+			items := append(ls.Items, ls2.Items...)
+			if len(items) != 4 {
+				t.Errorf("incorrect number of pods for eraser deployment. should be 4 but was %d", len(items))
+			}
+
+			for _, pod := range items {
+				found := false
+				for _, secret := range pod.Spec.ImagePullSecrets {
+					if secret.Name == util.EraserPullSecret {
+						found = true
+						break
+					}
+				}
+
+				if !found {
+					t.Errorf("pod %s does not have secret set", pod.ObjectMeta.Name)
+				}
+			}
+
+			return ctx
+		}).
+		Assess("Get logs", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			if err := util.GetPodLogs(ctx, cfg, t, false); err != nil {
+				t.Error("error getting collector pod logs", err)
+			}
+
+			if err := util.GetManagerLogs(ctx, cfg, t); err != nil {
+				t.Error("error getting manager logs", err)
+			}
+
+			return ctx
+		}).
+		Feature()
+
+	util.Testenv.Test(t, pullSecretsPropagated)
+}

--- a/test/e2e/tests/helm_pull_secret/eraser_test.go
+++ b/test/e2e/tests/helm_pull_secret/eraser_test.go
@@ -20,10 +20,12 @@ import (
 
 const (
 	collectorLabel = "name=collector"
+
+	expectedPods = 4
 )
 
-func TestCollectorExcluded(t *testing.T) {
-	pullSecretsPropagated := features.New("Collector pods completed").
+func TestHelmPullSecret(t *testing.T) {
+	pullSecretsPropagated := features.New("Image Pull Secrets").
 		Assess("All pods should have the correct pull secret", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			c, err := cfg.NewClient()
 			if err != nil {
@@ -53,8 +55,8 @@ func TestCollectorExcluded(t *testing.T) {
 			})
 
 			items := append(ls.Items, ls2.Items...)
-			if len(items) != 4 {
-				t.Errorf("incorrect number of pods for eraser deployment. should be 4 but was %d", len(items))
+			if len(items) != expectedPods {
+				t.Errorf("incorrect number of pods for eraser deployment. should be %d but was %d", expectedPods, len(items))
 			}
 
 			for _, pod := range items {

--- a/test/e2e/tests/helm_pull_secret/eraser_test.go
+++ b/test/e2e/tests/helm_pull_secret/eraser_test.go
@@ -62,7 +62,7 @@ func TestHelmPullSecret(t *testing.T) {
 			for _, pod := range items {
 				found := false
 				for _, secret := range pod.Spec.ImagePullSecrets {
-					if secret.Name == util.EraserPullSecret {
+					if secret.Name == util.ImagePullSecret {
 						found = true
 						break
 					}

--- a/test/e2e/tests/helm_pull_secret/main_test.go
+++ b/test/e2e/tests/helm_pull_secret/main_test.go
@@ -43,7 +43,7 @@ func TestMain(m *testing.M) {
 			"--set", util.CollectorImageTag.Set(collectorImage.Tag),
 			"--set", util.ManagerImageRepo.Set(managerImage.Repo),
 			"--set", util.ManagerImageTag.Set(managerImage.Tag),
-			"--set", util.EraserPullSecretName.Set(util.EraserPullSecret),
+			"--set-json", util.EraserPullSecrets.Set(util.EraserPullSecretJSON),
 			"--set", `controllerManager.additionalArgs={--job-cleanup-on-success-delay=2m}`),
 	).Finish(
 		envfuncs.DestroyKindCluster(util.KindClusterName),

--- a/test/e2e/tests/helm_pull_secret/main_test.go
+++ b/test/e2e/tests/helm_pull_secret/main_test.go
@@ -1,0 +1,52 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"os"
+	"testing"
+
+	eraserv1alpha1 "github.com/Azure/eraser/api/v1alpha1"
+	"github.com/Azure/eraser/test/e2e/util"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/e2e-framework/pkg/env"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+)
+
+func TestMain(m *testing.M) {
+	utilruntime.Must(eraserv1alpha1.AddToScheme(scheme.Scheme))
+
+	eraserImage := util.ParsedImages.EraserImage
+	managerImage := util.ParsedImages.ManagerImage
+	collectorImage := util.ParsedImages.CollectorImage
+	scannerImage := util.ParsedImages.ScannerImage
+
+	util.Testenv = env.NewWithConfig(envconf.New())
+	// Create KinD Cluster
+	util.Testenv.Setup(
+		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, "../../kind-config.yaml"),
+		envfuncs.CreateNamespace(util.TestNamespace),
+		envfuncs.CreateNamespace(util.EraserNamespace),
+		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.ManagerImage),
+		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.Image),
+		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.CollectorImage),
+		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.ScannerImage),
+		util.DeployEraserHelm(util.EraserNamespace,
+			"--set", util.ScannerImageRepo.Set(scannerImage.Repo),
+			"--set", util.ScannerImageTag.Set(scannerImage.Tag),
+			"--set", util.EraserImageRepo.Set(eraserImage.Repo),
+			"--set", util.EraserImageTag.Set(eraserImage.Tag),
+			"--set", util.CollectorImageRepo.Set(collectorImage.Repo),
+			"--set", util.CollectorImageTag.Set(collectorImage.Tag),
+			"--set", util.ManagerImageRepo.Set(managerImage.Repo),
+			"--set", util.ManagerImageTag.Set(managerImage.Tag),
+			"--set", util.EraserPullSecretName.Set(util.EraserPullSecret),
+			"--set", `controllerManager.additionalArgs={--job-cleanup-on-success-delay=2m}`),
+	).Finish(
+		envfuncs.DestroyKindCluster(util.KindClusterName),
+	)
+	os.Exit(util.Testenv.Run(m))
+}

--- a/test/e2e/tests/helm_pull_secret/main_test.go
+++ b/test/e2e/tests/helm_pull_secret/main_test.go
@@ -43,7 +43,7 @@ func TestMain(m *testing.M) {
 			"--set", util.CollectorImageTag.Set(collectorImage.Tag),
 			"--set", util.ManagerImageRepo.Set(managerImage.Repo),
 			"--set", util.ManagerImageTag.Set(managerImage.Tag),
-			"--set-json", util.EraserPullSecrets.Set(util.EraserPullSecretJSON),
+			"--set-json", util.ImagePullSecrets.Set(util.ImagePullSecretJSON),
 			"--set", `controllerManager.additionalArgs={--job-cleanup-on-success-delay=2m}`),
 	).Finish(
 		envfuncs.DestroyKindCluster(util.KindClusterName),

--- a/test/e2e/util/utils.go
+++ b/test/e2e/util/utils.go
@@ -48,19 +48,21 @@ const (
 
 	ImageCollectorShared = "imagecollector-shared"
 	Prune                = "imagelist"
+	EraserPullSecret     = "testsecret"
 	FilterNodeName       = "eraser-e2e-test-worker"
 	FilterNodeSelector   = "kubernetes.io/hostname=eraser-e2e-test-worker"
 	FilterLabelKey       = "eraser.sh/cleanup.filter"
 	FilterLabelValue     = "true"
 
-	ScannerImageRepo   = HelmPath("scanner.image.repository")
-	ScannerImageTag    = HelmPath("scanner.image.tag")
-	CollectorImageRepo = HelmPath("collector.image.repository")
-	CollectorImageTag  = HelmPath("collector.image.tag")
-	ManagerImageRepo   = HelmPath("controllerManager.image.repository")
-	ManagerImageTag    = HelmPath("controllerManager.image.tag")
-	EraserImageRepo    = HelmPath("eraser.image.repository")
-	EraserImageTag     = HelmPath("eraser.image.tag")
+	ScannerImageRepo     = HelmPath("scanner.image.repository")
+	ScannerImageTag      = HelmPath("scanner.image.tag")
+	CollectorImageRepo   = HelmPath("collector.image.repository")
+	CollectorImageTag    = HelmPath("collector.image.tag")
+	ManagerImageRepo     = HelmPath("controllerManager.image.repository")
+	ManagerImageTag      = HelmPath("controllerManager.image.tag")
+	EraserImageRepo      = HelmPath("eraser.image.repository")
+	EraserImageTag       = HelmPath("eraser.image.tag")
+	EraserPullSecretName = HelmPath("eraserPullSecretName")
 )
 
 var (

--- a/test/e2e/util/utils.go
+++ b/test/e2e/util/utils.go
@@ -54,15 +54,15 @@ const (
 	FilterLabelKey       = "eraser.sh/cleanup.filter"
 	FilterLabelValue     = "true"
 
-	ScannerImageRepo     = HelmPath("scanner.image.repository")
-	ScannerImageTag      = HelmPath("scanner.image.tag")
-	CollectorImageRepo   = HelmPath("collector.image.repository")
-	CollectorImageTag    = HelmPath("collector.image.tag")
-	ManagerImageRepo     = HelmPath("controllerManager.image.repository")
-	ManagerImageTag      = HelmPath("controllerManager.image.tag")
-	EraserImageRepo      = HelmPath("eraser.image.repository")
-	EraserImageTag       = HelmPath("eraser.image.tag")
-	EraserPullSecretName = HelmPath("eraserPullSecretName")
+	ScannerImageRepo   = HelmPath("scanner.image.repository")
+	ScannerImageTag    = HelmPath("scanner.image.tag")
+	CollectorImageRepo = HelmPath("collector.image.repository")
+	CollectorImageTag  = HelmPath("collector.image.tag")
+	ManagerImageRepo   = HelmPath("controllerManager.image.repository")
+	ManagerImageTag    = HelmPath("controllerManager.image.tag")
+	EraserImageRepo    = HelmPath("eraser.image.repository")
+	EraserImageTag     = HelmPath("eraser.image.tag")
+	EraserPullSecrets  = HelmPath("eraserPullSecrets")
 )
 
 var (
@@ -78,8 +78,9 @@ var (
 	EraserNamespace    = pkgUtil.GetNamespace()
 	TestLogDir         = os.Getenv("TEST_LOGDIR")
 
-	ParsedImages *Images
-	Timeout      = time.Minute * 5
+	ParsedImages         *Images
+	Timeout              = time.Minute * 5
+	EraserPullSecretJSON = fmt.Sprintf(`[{"name":"%s"}]`, EraserPullSecret)
 )
 
 type (

--- a/test/e2e/util/utils.go
+++ b/test/e2e/util/utils.go
@@ -48,7 +48,7 @@ const (
 
 	ImageCollectorShared = "imagecollector-shared"
 	Prune                = "imagelist"
-	EraserPullSecret     = "testsecret"
+	ImagePullSecret      = "testsecret"
 	FilterNodeName       = "eraser-e2e-test-worker"
 	FilterNodeSelector   = "kubernetes.io/hostname=eraser-e2e-test-worker"
 	FilterLabelKey       = "eraser.sh/cleanup.filter"
@@ -62,7 +62,7 @@ const (
 	ManagerImageTag    = HelmPath("controllerManager.image.tag")
 	EraserImageRepo    = HelmPath("eraser.image.repository")
 	EraserImageTag     = HelmPath("eraser.image.tag")
-	EraserPullSecrets  = HelmPath("eraserPullSecrets")
+	ImagePullSecrets   = HelmPath("imagePullSecrets")
 )
 
 var (
@@ -78,9 +78,9 @@ var (
 	EraserNamespace    = pkgUtil.GetNamespace()
 	TestLogDir         = os.Getenv("TEST_LOGDIR")
 
-	ParsedImages         *Images
-	Timeout              = time.Minute * 5
-	EraserPullSecretJSON = fmt.Sprintf(`[{"name":"%s"}]`, EraserPullSecret)
+	ParsedImages        *Images
+	Timeout             = time.Minute * 5
+	ImagePullSecretJSON = fmt.Sprintf(`[{"name":"%s"}]`, ImagePullSecret)
 )
 
 type (

--- a/third_party/open-policy-agent/gatekeeper/helmify/kustomize-for-helm.yaml
+++ b/third_party/open-policy-agent/gatekeeper/helmify/kustomize-for-helm.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   template:
     spec:
+      HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_PULL_SECRETS: ""
       containers:
       - name: manager
         args:
@@ -19,6 +20,9 @@ spec:
         - HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_ADDITIONAL_ARGS
         command:
         - /manager
+        env:
+          - name: ERASER_PULL_SECRET_NAME
+            value: "{{ .Values.eraserPullSecretName }}"
         image: "{{ .Values.controllerManager.image.repository }}:{{ .Values.controllerManager.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.controllerManager.image.pullPolicy }}"
         livenessProbe:

--- a/third_party/open-policy-agent/gatekeeper/helmify/kustomize-for-helm.yaml
+++ b/third_party/open-policy-agent/gatekeeper/helmify/kustomize-for-helm.yaml
@@ -21,8 +21,8 @@ spec:
         command:
         - /manager
         env:
-          - name: ERASER_PULL_SECRET_NAME
-            value: "{{ .Values.eraserPullSecretName }}"
+          - name: ERASER_PULL_SECRET_NAMES
+            value: HELMSUBST_CONTROLLER_MANAGER_PULL_SECRETS_LIST
         image: "{{ .Values.controllerManager.image.repository }}:{{ .Values.controllerManager.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.controllerManager.image.pullPolicy }}"
         livenessProbe:

--- a/third_party/open-policy-agent/gatekeeper/helmify/replacements.go
+++ b/third_party/open-policy-agent/gatekeeper/helmify/replacements.go
@@ -9,10 +9,10 @@ var replacements = map[string]string{
 	`- HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_ERASER_ARGS`:           `{{- if .Values.eraser.image.args }}{{- range .Values.eraser.image.args }}{{ nindent 8 "- --eraser-arg=" }}{{ . }}{{- end -}}{{ end }}`,
 	`- HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_COLLECTOR_ARGS`:        `{{- if .Values.collector.image.args }}{{- range .Values.collector.image.args }}{{ nindent 8 "- --collector-arg=" }}{{ . }}{{- end -}}{{ end }}`,
 	`- HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_ADDITIONAL_ARGS`:       `{{- if .Values.controllerManager.additionalArgs }}{{- range .Values.controllerManager.additionalArgs }}{{ nindent 8 "- " }}{{ . }}{{- end -}}{{ end }}`,
-	`HELMSUBST_CONTROLLER_MANAGER_PULL_SECRETS_LIST`:                  `"{{- range $i, $e := .Values.eraserPullSecrets -}}{{- range $k, $v := $e }}{{- if $i -}},{{- end -}}{{- $v -}}{{- end -}}{{- end }}"`,
+	`HELMSUBST_CONTROLLER_MANAGER_PULL_SECRETS_LIST`:                  `"{{- range $i, $e := .Values.imagePullSecrets -}}{{- range $k, $v := $e }}{{- if $i -}},{{- end -}}{{- $v -}}{{- end -}}{{- end }}"`,
 
-	`HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_PULL_SECRETS: ""`: `{{- if .Values.eraserPullSecrets }}
+	`HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_PULL_SECRETS: ""`: `{{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml .Values.eraserPullSecrets | nindent 8 }}
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       {{- end }}`,
 }

--- a/third_party/open-policy-agent/gatekeeper/helmify/replacements.go
+++ b/third_party/open-policy-agent/gatekeeper/helmify/replacements.go
@@ -9,4 +9,8 @@ var replacements = map[string]string{
 	`- HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_ERASER_ARGS`:           `{{- if .Values.eraser.image.args }}{{- range .Values.eraser.image.args }}{{ nindent 8 "- --eraser-arg=" }}{{ . }}{{- end -}}{{ end }}`,
 	`- HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_COLLECTOR_ARGS`:        `{{- if .Values.collector.image.args }}{{- range .Values.collector.image.args }}{{ nindent 8 "- --collector-arg=" }}{{ . }}{{- end -}}{{ end }}`,
 	`- HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_ADDITIONAL_ARGS`:       `{{- if .Values.controllerManager.additionalArgs }}{{- range .Values.controllerManager.additionalArgs }}{{ nindent 8 "- " }}{{ . }}{{- end -}}{{ end }}`,
+	`HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_PULL_SECRETS: ""`: `{{- if .Values.eraserPullSecretName }}
+      imagePullSecrets:
+        - name: "{{ .Values.eraserPullSecretName }}"
+      {{- end }}`,
 }

--- a/third_party/open-policy-agent/gatekeeper/helmify/replacements.go
+++ b/third_party/open-policy-agent/gatekeeper/helmify/replacements.go
@@ -9,8 +9,10 @@ var replacements = map[string]string{
 	`- HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_ERASER_ARGS`:           `{{- if .Values.eraser.image.args }}{{- range .Values.eraser.image.args }}{{ nindent 8 "- --eraser-arg=" }}{{ . }}{{- end -}}{{ end }}`,
 	`- HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_COLLECTOR_ARGS`:        `{{- if .Values.collector.image.args }}{{- range .Values.collector.image.args }}{{ nindent 8 "- --collector-arg=" }}{{ . }}{{- end -}}{{ end }}`,
 	`- HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_ADDITIONAL_ARGS`:       `{{- if .Values.controllerManager.additionalArgs }}{{- range .Values.controllerManager.additionalArgs }}{{ nindent 8 "- " }}{{ . }}{{- end -}}{{ end }}`,
-	`HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_PULL_SECRETS: ""`: `{{- if .Values.eraserPullSecretName }}
+	`HELMSUBST_CONTROLLER_MANAGER_PULL_SECRETS_LIST`:                  `"{{- range $i, $e := .Values.eraserPullSecrets -}}{{- range $k, $v := $e }}{{- if $i -}},{{- end -}}{{- $v -}}{{- end -}}{{- end }}"`,
+
+	`HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_PULL_SECRETS: ""`: `{{- if .Values.eraserPullSecrets }}
       imagePullSecrets:
-        - name: "{{ .Values.eraserPullSecretName }}"
+        {{- toYaml .Values.eraserPullSecrets | nindent 8 }}
       {{- end }}`,
 }

--- a/third_party/open-policy-agent/gatekeeper/helmify/static/values.yaml
+++ b/third_party/open-policy-agent/gatekeeper/helmify/static/values.yaml
@@ -43,3 +43,4 @@ scanner:
     args: []
 
 nameOverride: ""
+eraserPullSecretName: ""

--- a/third_party/open-policy-agent/gatekeeper/helmify/static/values.yaml
+++ b/third_party/open-policy-agent/gatekeeper/helmify/static/values.yaml
@@ -43,4 +43,4 @@ scanner:
     args: []
 
 nameOverride: ""
-eraserPullSecretName: ""
+eraserPullSecrets: []

--- a/third_party/open-policy-agent/gatekeeper/helmify/static/values.yaml
+++ b/third_party/open-policy-agent/gatekeeper/helmify/static/values.yaml
@@ -43,4 +43,4 @@ scanner:
     args: []
 
 nameOverride: ""
-eraserPullSecrets: []
+imagePullSecrets: []


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows the user to set a set of global `imagePullSecrets`, for retrieving eraser component images (eraser, manager, scanner, collector) from private registries.

To use:
- Create a docker-registry secret (ex `mysecret`) in the same namespace in which eraser will be deployed
- Deploy with helm, by using the flag `--set-json eraserPullSecrets='[ { "name": "mysecret" } ]'`

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #492 

**Special notes for your reviewer**:
Have fun and happy reviewing
