### PR TITLE
fix: guard against nil when connection to v1 CRI fails

### DIFF
--- a/pkg/cri/client.go
+++ b/pkg/cri/client.go
@@ -70,14 +70,24 @@ func newClientWithFallback(ctx context.Context, conn *grpc.ClientConn) (Eraser, 
 func tryV1Alpha2(ctx context.Context, conn *grpc.ClientConn) (string, error) {
 	runtimeClientV1Alpha2 := v1alpha2.NewRuntimeServiceClient(conn)
 	req2 := v1alpha2.VersionRequest{}
+
 	respv1Alpha2, err := runtimeClientV1Alpha2.Version(ctx, &req2)
+	if err != nil {
+		return "", err
+	}
+
 	return respv1Alpha2.RuntimeApiVersion, err
 }
 
 func tryV1(ctx context.Context, conn *grpc.ClientConn) (string, error) {
 	runtimeClient := v1.NewRuntimeServiceClient(conn)
 	req := v1.VersionRequest{}
+
 	resp, err := runtimeClient.Version(ctx, &req)
+	if err != nil {
+		return "", err
+	}
+
 	return resp.RuntimeApiVersion, err
 }
 


### PR DESCRIPTION
Signed-off-by: Peter Engelbert <pmengelbert@gmail.com>

**What this PR does / why we need it**:
Because we aren't returning the response directly (just the runtime version as a string), we need to check for the error before returning.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
May be the cause of CI failures