### PR TITLE
test: create additional test using containerd v1.6.x

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -248,6 +248,7 @@ jobs:
         run: |
           export PATH="${KIND_DIR}:${PATH}"
           make e2e-test \
+            KUBERNETES_VERSION=1.23.13 \
             E2E_TESTS=${{ matrix.E2E_TEST }} \
             ERASER_IMG=${ERASER_IMG} \
             MANAGER_IMG=${MANAGER_IMG} \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -176,6 +176,11 @@ jobs:
           run: make docker-build-collector COLLECTOR_IMG=${COLLECTOR_IMG}
         - name: Build trivy-scanner
           run: make docker-build-trivy-scanner TRIVY_SCANNER_IMG=${SCANNER_IMG}
+        - name: Install kind v0.17.0
+          run: |
+            KIND_DIR=$(mktemp -d)
+            curl -Lo ${KIND_DIR}/kind https://kind.sigs.k8s.io/dl/v0.17.0/kind-linux-amd64
+            echo KIND_DIR=${KIND_DIR} >> GITHUB_ENV
         - name: Run e2e test
           run: |
             make e2e-test \
@@ -191,6 +196,70 @@ jobs:
             name: test_logs
             path: ${{ github.workspace }}/test_logs/*
             retention-days: 1
+
+  containerd-test:
+    name: "Test with containerd 1.5.x"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5
+        with:
+          egress-policy: audit
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - name: Setup buildx instance
+        uses: docker/setup-buildx-action@v2
+        with:
+          use: true
+      - uses: actions/cache@v3.0.11
+        with:
+          key: ${{ runner.OS }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+      - uses: crazy-max/ghaction-github-runtime@v2
+      - name: Set env
+        run: |
+          echo ERASER_IMG=eraser:test >> $GITHUB_ENV
+          echo MANAGER_IMG=manager:test >> $GITHUB_ENV
+          echo COLLECTOR_IMG=collector:test >> $GITHUB_ENV
+          echo SCANNER_IMG=scanner:test >> $GITHUB_ENV
+      - name: Build eraser-manager
+        run: make docker-build-manager MANAGER_IMG=${MANAGER_IMG}
+      - name: Build eraser
+        run: make docker-build-eraser ERASER_IMG=${ERASER_IMG}
+      - name: Build collector
+        run: make docker-build-collector COLLECTOR_IMG=${COLLECTOR_IMG}
+      - name: Build trivy-scanner
+        run: make docker-build-trivy-scanner TRIVY_SCANNER_IMG=${SCANNER_IMG}
+      - name: Install kind v0.12.0
+        run: |
+          KIND_DIR=$(mktemp -d)
+          curl -Lo ${KIND_DIR}/kind https://kind.sigs.k8s.io/dl/v0.12.0/kind-linux-amd64
+          echo KIND_DIR=${KIND_DIR} >> GITHUB_ENV
+      - name: Run e2e test
+        run: |
+          export PATH="${KIND_DIR}:${PATH}"
+          make e2e-test \
+            E2E_TESTS=${{ matrix.E2E_TEST }} \
+            ERASER_IMG=${ERASER_IMG} \
+            MANAGER_IMG=${MANAGER_IMG} \
+            COLLECTOR_IMG=${COLLECTOR_IMG} \
+            TRIVY_SCANNER_IMG=${SCANNER_IMG} \
+            E2E_TESTS=./test/e2e/tests/collector_pipeline
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: test_logs
+          path: ${{ github.workspace }}/test_logs/*
+          retention-days: 1
 
   scan_vulnerabilities:
     name: "[Trivy] Scan for vulnerabilities"


### PR DESCRIPTION
By default the e2e test framework will install kind v1.12.0 (if not already installed), which uses containerd version 1.5.x. Versions of kind >= v1.13.0 use containerd version 1.6.x. To ensure wider test coverage, one test will install kind v1.12.0, while the bulk of the tests will install kind v1.17.0.
