### PR TITLE
feat: tolerate everything

### DIFF
--- a/controllers/imagejob/imagejob_controller.go
+++ b/controllers/imagejob/imagejob_controller.go
@@ -55,15 +55,6 @@ var (
 
 	defaultTolerations = []corev1.Toleration{
 		{
-			Effect:   corev1.TaintEffectNoExecute,
-			Operator: corev1.TolerationOpExists,
-		},
-		{
-			Effect:   corev1.TaintEffectNoSchedule,
-			Operator: corev1.TolerationOpExists,
-		},
-		{
-			Effect:   corev1.TaintEffectPreferNoSchedule,
 			Operator: corev1.TolerationOpExists,
 		},
 	}

--- a/test/e2e/tests/imagelist_rm_images/eraser_test.go
+++ b/test/e2e/tests/imagelist_rm_images/eraser_test.go
@@ -24,6 +24,8 @@ import (
 const (
 	collectorLabel = "name=collector"
 	eraserLabel    = "name=eraser"
+
+	restartTimeout = time.Minute
 )
 
 func TestImageListTriggersEraserImageJob(t *testing.T) {
@@ -174,7 +176,7 @@ func TestImageListTriggersEraserImageJob(t *testing.T) {
 			// until a timeout is reached, make sure there are no pods matching
 			// the selector name=eraser
 			client := cfg.Client()
-			ctxT2, cancel := context.WithTimeout(ctx, util.Timeout)
+			ctxT2, cancel := context.WithTimeout(ctx, restartTimeout)
 			defer cancel()
 			util.CheckDeploymentCleanedUp(ctxT2, t, client)
 


### PR DESCRIPTION
According to [the kubernetes docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/), An empty `key` with operator `Exists` matches all keys, values and effects which means this will tolerate everything.

Signed-off-by: Peter Engelbert <pmengelbert@gmail.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**
Fixes #518 

**Special notes for your reviewer**:
