### PR TITLE
test: catch broken scanner

### DIFF
--- a/controllers/imagecollector/imagecollector_controller.go
+++ b/controllers/imagecollector/imagecollector_controller.go
@@ -306,10 +306,14 @@ func (r *Reconciler) createImageJob(ctx context.Context, req ctrl.Request, argsC
 	}
 
 	if !scanDisabled {
+		deleteFailedString := strconv.FormatBool(*deleteScanFailedImages)
+		scanFailedArg := fmt.Sprintf("--delete-scan-failed-images=%s", deleteFailedString)
+		scannerArgs = append(scannerArgs, scanFailedArg)
+
 		scannerContainer := corev1.Container{
 			Name:  "trivy-scanner",
 			Image: *scannerImage,
-			Args:  append(scannerArgs, "delete-scan-failed-images="+strconv.FormatBool(*deleteScanFailedImages)),
+			Args:  scannerArgs,
 			VolumeMounts: []corev1.VolumeMount{
 				{MountPath: "/run/eraser.sh/shared-data", Name: "shared-data"},
 			},

--- a/test/e2e/tests/collector_disable_scan/main_test.go
+++ b/test/e2e/tests/collector_disable_scan/main_test.go
@@ -40,7 +40,8 @@ func TestMain(m *testing.M) {
 			"--set", util.CollectorImageTag.Set(collectorImage.Tag),
 			"--set", util.ManagerImageRepo.Set(managerImage.Repo),
 			"--set", util.ManagerImageTag.Set(managerImage.Tag),
-			"--set", `controllerManager.additionalArgs={--job-cleanup-on-success-delay=1m}`),
+			"--set", util.ManagerAdditionalArgs.Set("--job-cleanup-on-success-delay=1m").String(),
+		),
 	).Finish(
 		envfuncs.DestroyKindCluster(util.KindClusterName),
 	)

--- a/test/e2e/tests/collector_ensure_scan/eraser_test.go
+++ b/test/e2e/tests/collector_ensure_scan/eraser_test.go
@@ -1,0 +1,39 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/eraser/test/e2e/util"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func TestEnsureScannerFunctions(t *testing.T) {
+	collectScanErasePipelineFeat := features.New("Collector pods should run automatically, trigger the scanner, then the eraser pods. Manifest deployment test.").
+		Assess("Vulnerable Image successfully deleted from all nodes", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ctxT, cancel := context.WithTimeout(ctx, util.Timeout)
+			defer cancel()
+			util.CheckImageRemoved(ctxT, t, util.GetClusterNodes(t), util.Alpine)
+
+			return ctx
+		}).
+		Assess("Get logs", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			if err := util.GetManagerLogs(ctx, cfg, t); err != nil {
+				t.Error("error getting manager logs", err)
+			}
+
+			if err := util.GetPodLogs(ctx, cfg, t, false); err != nil {
+				t.Error("error getting manager logs", err)
+			}
+
+			return ctx
+		}).
+		Feature()
+
+	util.Testenv.Test(t, collectScanErasePipelineFeat)
+}

--- a/test/e2e/tests/collector_ensure_scan/main_test.go
+++ b/test/e2e/tests/collector_ensure_scan/main_test.go
@@ -1,0 +1,53 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"os"
+	"testing"
+
+	eraserv1alpha1 "github.com/Azure/eraser/api/v1alpha1"
+	"github.com/Azure/eraser/test/e2e/util"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/e2e-framework/pkg/env"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+)
+
+func TestMain(m *testing.M) {
+	utilruntime.Must(eraserv1alpha1.AddToScheme(scheme.Scheme))
+
+	eraserImage := util.ParsedImages.EraserImage
+	managerImage := util.ParsedImages.ManagerImage
+	collectorImage := util.ParsedImages.CollectorImage
+	scannerImage := util.ParsedImages.ScannerImage
+
+	util.Testenv = env.NewWithConfig(envconf.New())
+	// Create KinD Cluster
+	util.Testenv.Setup(
+		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, "../../kind-config.yaml"),
+		envfuncs.CreateNamespace(util.TestNamespace),
+		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.ManagerImage),
+		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.Image),
+		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.CollectorImage),
+		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.VulnerableImage),
+		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.NonVulnerableImage),
+		envfuncs.LoadDockerImageToCluster(util.KindClusterName, util.ScannerImage),
+		util.DeployEraserHelm(util.TestNamespace,
+			"--set", util.ScannerImageRepo.Set(scannerImage.Repo),
+			"--set", util.ScannerImageTag.Set(scannerImage.Tag),
+			"--set", util.EraserImageRepo.Set(eraserImage.Repo),
+			"--set", util.EraserImageTag.Set(eraserImage.Tag),
+			"--set", util.CollectorImageRepo.Set(collectorImage.Repo),
+			"--set", util.CollectorImageTag.Set(collectorImage.Tag),
+			"--set", util.ManagerImageRepo.Set(managerImage.Repo),
+			"--set", util.ManagerImageTag.Set(managerImage.Tag),
+			"--set", util.ManagerAdditionalArgs.Set("--job-cleanup-on-success-delay=2m").String(),
+		),
+	).Finish(
+		envfuncs.DestroyKindCluster(util.KindClusterName),
+	)
+	os.Exit(util.Testenv.Run(m))
+}

--- a/test/e2e/tests/collector_skip_excluded/main_test.go
+++ b/test/e2e/tests/collector_skip_excluded/main_test.go
@@ -46,7 +46,8 @@ func TestMain(m *testing.M) {
 			"--set", util.CollectorImageTag.Set(collectorImage.Tag),
 			"--set", util.ManagerImageRepo.Set(managerImage.Repo),
 			"--set", util.ManagerImageTag.Set(managerImage.Tag),
-			"--set", `controllerManager.additionalArgs={--job-cleanup-on-success-delay=2m}`),
+			"--set", util.ManagerAdditionalArgs.Set("--job-cleanup-on-success-delay=2m").String(),
+		),
 	).Finish(
 		envfuncs.DestroyKindCluster(util.KindClusterName),
 	)

--- a/test/e2e/tests/helm_pull_secret/main_test.go
+++ b/test/e2e/tests/helm_pull_secret/main_test.go
@@ -43,7 +43,8 @@ func TestMain(m *testing.M) {
 			"--set", util.ManagerImageRepo.Set(managerImage.Repo),
 			"--set", util.ManagerImageTag.Set(managerImage.Tag),
 			"--set-json", util.ImagePullSecrets.Set(util.ImagePullSecretJSON),
-			"--set", `controllerManager.additionalArgs={--job-cleanup-on-success-delay=2m}`),
+			"--set", util.ManagerAdditionalArgs.Set("--job-cleanup-on-success-delay=2m").String(),
+		),
 	).Finish(
 		envfuncs.DestroyKindCluster(util.KindClusterName),
 	)

--- a/test/e2e/tests/imagelist_alias/main_test.go
+++ b/test/e2e/tests/imagelist_alias/main_test.go
@@ -37,7 +37,8 @@ func TestMain(m *testing.M) {
 			"--set", util.EraserImageTag.Set(eraserImage.Tag),
 			"--set", util.ManagerImageRepo.Set(managerImage.Repo),
 			"--set", util.ManagerImageTag.Set(managerImage.Tag),
-			"--set", `controllerManager.additionalArgs={--job-cleanup-on-success-delay=1m}`),
+			"--set", util.ManagerAdditionalArgs.Set("--job-cleanup-on-success-delay=1m").String(),
+		),
 	).Finish(
 		envfuncs.DestroyKindCluster(util.KindClusterName),
 	)

--- a/test/e2e/tests/imagelist_exclusion_list/main_test.go
+++ b/test/e2e/tests/imagelist_exclusion_list/main_test.go
@@ -36,7 +36,8 @@ func TestMain(m *testing.M) {
 			"--set", util.EraserImageTag.Set(eraserImage.Tag),
 			"--set", util.ManagerImageRepo.Set(managerImage.Repo),
 			"--set", util.ManagerImageTag.Set(managerImage.Tag),
-			"--set", `controllerManager.additionalArgs={--job-cleanup-on-success-delay=1m}`),
+			"--set", util.ManagerAdditionalArgs.Set("--job-cleanup-on-success-delay=1m").String(),
+		),
 	).Finish(
 		envfuncs.DestroyKindCluster(util.KindClusterName),
 	)

--- a/test/e2e/tests/imagelist_include_nodes/main_test.go
+++ b/test/e2e/tests/imagelist_include_nodes/main_test.go
@@ -36,7 +36,8 @@ func TestMain(m *testing.M) {
 			"--set", util.EraserImageTag.Set(eraserImage.Tag),
 			"--set", util.ManagerImageRepo.Set(managerImage.Repo),
 			"--set", util.ManagerImageTag.Set(managerImage.Tag),
-			"--set", `controllerManager.additionalArgs={--filter-nodes=include, --job-cleanup-on-success-delay=1m}`),
+			"--set", util.ManagerAdditionalArgs.Set("--filter-nodes=include").Set("--job-cleanup-on-success-delay=1m").String(),
+		),
 	).Finish(
 		envfuncs.DestroyKindCluster(util.KindClusterName),
 	)

--- a/test/e2e/tests/imagelist_prune_images/main_test.go
+++ b/test/e2e/tests/imagelist_prune_images/main_test.go
@@ -36,7 +36,8 @@ func TestMain(m *testing.M) {
 			"--set", util.EraserImageTag.Set(eraserImage.Tag),
 			"--set", util.ManagerImageRepo.Set(managerImage.Repo),
 			"--set", util.ManagerImageTag.Set(managerImage.Tag),
-			"--set", `controllerManager.additionalArgs={--job-cleanup-on-success-delay=1m}`),
+			"--set", util.ManagerAdditionalArgs.Set("--job-cleanup-on-success-delay=1m").String(),
+		),
 	).Finish(
 		envfuncs.DestroyKindCluster(util.KindClusterName),
 	)

--- a/test/e2e/tests/imagelist_skip_nodes/main_test.go
+++ b/test/e2e/tests/imagelist_skip_nodes/main_test.go
@@ -36,7 +36,8 @@ func TestMain(m *testing.M) {
 			"--set", util.EraserImageTag.Set(eraserImage.Tag),
 			"--set", util.ManagerImageRepo.Set(managerImage.Repo),
 			"--set", util.ManagerImageTag.Set(managerImage.Tag),
-			"--set", `controllerManager.additionalArgs={--job-cleanup-on-success-delay=1m}`),
+			"--set", util.ManagerAdditionalArgs.Set("--job-cleanup-on-success-delay=1m").String(),
+		),
 	).Finish(
 		envfuncs.DestroyKindCluster(util.KindClusterName),
 	)

--- a/test/e2e/tests/metrics_test_disable_scanner/eraser_test.go
+++ b/test/e2e/tests/metrics_test_disable_scanner/eraser_test.go
@@ -19,7 +19,7 @@ const (
 	expectedImagesRemoved = 3
 )
 
-func TestMetrics(t *testing.T) {
+func TestMetricsWithScannerDisabled(t *testing.T) {
 	metrics := features.New("Images_removed_run_total metric should report 1").
 		Assess("Alpine image is removed", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			ctxT, cancel := context.WithTimeout(ctx, util.Timeout)

--- a/test/e2e/tests/metrics_test_disable_scanner/main_test.go
+++ b/test/e2e/tests/metrics_test_disable_scanner/main_test.go
@@ -41,7 +41,8 @@ func TestMain(m *testing.M) {
 			"--set", util.EraserImageTag.Set(eraserImage.Tag),
 			"--set", util.ManagerImageRepo.Set(managerImage.Repo),
 			"--set", util.ManagerImageTag.Set(managerImage.Tag),
-			"--set", `controllerManager.additionalArgs={--job-cleanup-on-success-delay=1m,--otlp-endpoint=otel-collector:4318}`),
+			"--set", util.ManagerAdditionalArgs.Set("--job-cleanup-on-success-delay=1m").Set("--otlp-endpoint=otel-collector:4318").String(),
+		),
 	).Finish(
 		envfuncs.DestroyKindCluster(util.KindClusterName),
 	)

--- a/test/e2e/tests/metrics_test_eraser/eraser_test.go
+++ b/test/e2e/tests/metrics_test_eraser/eraser_test.go
@@ -19,7 +19,7 @@ const (
 	expectedImagesRemoved = 3
 )
 
-func TestMetrics(t *testing.T) {
+func TestMetricsEraserOnly(t *testing.T) {
 	metrics := features.New("Images_removed_run_total metric should report 1").
 		Assess("Alpine image is removed", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			// deploy imagelist config

--- a/test/e2e/tests/metrics_test_eraser/main_test.go
+++ b/test/e2e/tests/metrics_test_eraser/main_test.go
@@ -38,7 +38,8 @@ func TestMain(m *testing.M) {
 			"--set", util.EraserImageTag.Set(eraserImage.Tag),
 			"--set", util.ManagerImageRepo.Set(managerImage.Repo),
 			"--set", util.ManagerImageTag.Set(managerImage.Tag),
-			"--set", `controllerManager.additionalArgs={--job-cleanup-on-success-delay=1m,--otlp-endpoint=otel-collector:4318}`),
+			"--set", util.ManagerAdditionalArgs.Set("--job-cleanup-on-success-delay=1m").Set("--otlp-endpoint=otel-collector:4318").String(),
+		),
 	).Finish(
 		envfuncs.DestroyKindCluster(util.KindClusterName),
 	)

--- a/test/e2e/tests/metrics_test_scanner/eraser_test.go
+++ b/test/e2e/tests/metrics_test_scanner/eraser_test.go
@@ -19,7 +19,7 @@ const (
 	expectedVulnerableImages = 3
 )
 
-func TestMetrics(t *testing.T) {
+func TestMetricsWithScanner(t *testing.T) {
 	metrics := features.New("Images_removed_run_total and vulnerable_images_run_total metrics should report >= 3").
 		Assess("Alpine image is removed", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			ctxT, cancel := context.WithTimeout(ctx, util.Timeout)

--- a/test/e2e/tests/metrics_test_scanner/main_test.go
+++ b/test/e2e/tests/metrics_test_scanner/main_test.go
@@ -44,7 +44,8 @@ func TestMain(m *testing.M) {
 			"--set", util.EraserImageTag.Set(eraserImage.Tag),
 			"--set", util.ManagerImageRepo.Set(managerImage.Repo),
 			"--set", util.ManagerImageTag.Set(managerImage.Tag),
-			"--set", `controllerManager.additionalArgs={--job-cleanup-on-success-delay=1m,--otlp-endpoint=otel-collector:4318}`),
+			"--set", util.ManagerAdditionalArgs.Set("--job-cleanup-on-success-delay=1m").Set("--otlp-endpoint=otel-collector:4318").Set("--delete-scan-failed-images=false").String(),
+		),
 	).Finish(
 		envfuncs.DestroyKindCluster(util.KindClusterName),
 	)

--- a/test/e2e/util/utils.go
+++ b/test/e2e/util/utils.go
@@ -81,6 +81,11 @@ var (
 	ParsedImages        *Images
 	Timeout             = time.Minute * 5
 	ImagePullSecretJSON = fmt.Sprintf(`[{"name":"%s"}]`, ImagePullSecret)
+
+	ManagerAdditionalArgs = HelmSet{
+		key:  "controllerManager.additionalArgs",
+		args: []string{"--delete-scan-failed-images=false"},
+	}
 )
 
 type (
@@ -97,10 +102,24 @@ type (
 	}
 
 	HelmPath string
+
+	HelmSet struct {
+		key  string
+		args []string
+	}
 )
 
 func (hp HelmPath) Set(val string) string {
 	return fmt.Sprintf("%s=%s", hp, val)
+}
+
+func (hs *HelmSet) Set(val ...string) *HelmSet {
+	hs.args = append(hs.args, val...)
+	return hs
+}
+
+func (hs *HelmSet) String() string {
+	return fmt.Sprintf("%s={%s}", hs.key, strings.Join(hs.args, ","))
 }
 
 func init() {


### PR DESCRIPTION
**What this PR does / why we need it**:
* Creates a test to catch when the scanner is broker
* Makes `--delete-scan-failed-images=false` the default behavior for most e2e tests
* Tidies some code
* Adds an append-only system for adding args to the controller manager for e2e tests

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #536 
