### PR TITLE
fix: check for otlp endpoint in scanner metrics

### DIFF
--- a/pkg/scanners/trivy/trivy.go
+++ b/pkg/scanners/trivy/trivy.go
@@ -116,11 +116,16 @@ func main() {
 		go runProfileServer()
 	}
 
+	recordMetrics := false
+	if os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") != "" {
+		recordMetrics = true
+	}
+
 	ctx := context.Background()
 	provider := template.NewImageProvider(
 		template.WithContext(ctx),
 		template.WithLogger(log),
-		template.WithMetrics(true),
+		template.WithMetrics(recordMetrics),
 		template.WithDeleteScanFailedImages(*deleteScanFailedImages),
 	)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds back check for otlp endpoint flag in scanner to determine if we record metrics.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #549

**Special notes for your reviewer**:
