### PR TITLE
fix: imagepullsecrets list

### DIFF
--- a/controllers/imagejob/imagejob_controller.go
+++ b/controllers/imagejob/imagejob_controller.go
@@ -533,9 +533,7 @@ func copyAndFillTemplateSpec(templateSpecTemplate *corev1.PodSpec, env []corev1.
 	secrets := os.Getenv("ERASER_PULL_SECRET_NAMES")
 	if secrets != "" {
 		for _, secret := range strings.Split(secrets, ",") {
-			templateSpec.ImagePullSecrets = []corev1.LocalObjectReference{{
-				Name: secret,
-			}}
+			templateSpec.ImagePullSecrets = append(templateSpec.ImagePullSecrets, corev1.LocalObjectReference{Name: secret})
 		}
 	}
 


### PR DESCRIPTION
There was an error by which image pull secrets would be overwritten if multiple were supplied. This commit fixes it.
Signed-off-by: Peter Engelbert <pmengelbert@gmail.com>
