### PR TITLE
fix: remove accidentally added code

### DIFF
--- a/controllers/imagejob/imagejob_controller.go
+++ b/controllers/imagejob/imagejob_controller.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +28,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -367,22 +365,9 @@ func (r *Reconciler) handleNewJob(ctx context.Context, imageJob *eraserv1.ImageJ
 			return err
 		}
 		log.Info("Started "+containerName+" pod on node", "nodeName", nodeName)
-
-		if err := wait.PollImmediate(time.Second, time.Minute, isPodReady(pod)); err != nil {
-			log.Error(err, "error waiting for PodReady phase", pod.Name, pod.Status.Phase)
-		}
 	}
 
 	return nil
-}
-
-func isPodReady(pod *corev1.Pod) wait.ConditionFunc {
-	return func() (bool, error) {
-		if pod.Status.Phase == corev1.PodPhase(corev1.PodReady) {
-			return true, nil
-		}
-		return false, nil
-	}
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/test/e2e/tests/imagelist_rm_images/eraser_test.go
+++ b/test/e2e/tests/imagelist_rm_images/eraser_test.go
@@ -107,7 +107,7 @@ func TestImageListTriggersEraserImageJob(t *testing.T) {
 					podNames = append(podNames, pod.ObjectMeta.Name)
 				}
 				return true, nil
-			}, wait.WithTimeout(util.Timeout), wait.WithInterval(time.Millisecond*500))
+			}, wait.WithTimeout(time.Minute*2), wait.WithInterval(time.Millisecond*500))
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
The v1 api changes accidentally restored a commit that should have been reverted. This PR removes it again. The code removed here is the cause of #537 .
