### PR TITLE
fix: remove explicit id and group from docker call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,6 +297,5 @@ version-docs:
 	docker run --rm \
 		-v $(shell pwd)/docs:/docs \
 		-w /docs \
-		-u $(shell id -u):$(shell id -g) \
 		node:${NODE_VERSION} \
 		sh -c "yarn install --frozen-lockfile && yarn run docusaurus docs:version ${NEWVERSION}"

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,11 @@ ifdef GENERATE_ATTESTATIONS
 _ATTESTATIONS := --attest type=sbom --attest type=provenance,mode=max
 endif
 
+IDFLAGS=
+ifeq (false,$(shell hack/rootless_docker.sh))
+IDFLAGS=-u $(shell id -u):$(shell id -g)
+endif
+
 OUTPUT_TYPE ?= type=docker
 TOOLS_DIR := hack/tools
 TOOLS_BIN_DIR := $(abspath $(TOOLS_DIR)/bin)
@@ -297,5 +302,6 @@ version-docs:
 	docker run --rm \
 		-v $(shell pwd)/docs:/docs \
 		-w /docs \
+		$(IDFLAGS) \
 		node:${NODE_VERSION} \
 		sh -c "yarn install --frozen-lockfile && yarn run docusaurus docs:version ${NEWVERSION}"

--- a/hack/rootless_docker.sh
+++ b/hack/rootless_docker.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+readarray -t uids < <(ps -C dockerd -o uid=)
+[[ "${#uids[@]}" != "1" ]] && exit 1
+
+if [ ${uids[0]} -ne 0 ]; then
+    echo true
+    exit 0
+fi
+
+echo false
+exit 1


### PR DESCRIPTION
including the explicit id:group in the `docker run` call breaks permissions in rootless docker setups.
