### PR TITLE
ci: pin golang image to 1.19.4-bullseye

### DIFF
--- a/build/tooling/Dockerfile
+++ b/build/tooling/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-bullseye
+FROM golang:1.19.4-bullseye
 
 RUN GO111MODULE=on go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.0
 RUN GO111MODULE=on go install k8s.io/code-generator/cmd/conversion-gen@v0.25.4

--- a/build/tooling/Dockerfile
+++ b/build/tooling/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.4-bullseye
+FROM golang@sha256:bb9811fad43a7d6fd2173248d8331b2dcf5ac9af20976b1937ecd214c5b8c383
 
 RUN GO111MODULE=on go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.0
 RUN GO111MODULE=on go install k8s.io/code-generator/cmd/conversion-gen@v0.25.4


### PR DESCRIPTION
There's an issue caused by the 1.19.5-bullseye image: https://github.com/docker-library/golang/issues/452

This will allow CI to succeed while the underlying issue is sorted out