### PR TITLE
feat: add cli option for custom runtime path

### DIFF
--- a/pkg/eraser/eraser.go
+++ b/pkg/eraser/eraser.go
@@ -26,10 +26,11 @@ import (
 )
 
 var (
-	runtimePtr    = flag.String("runtime", "containerd", "container runtime")
-	imageListPtr  = flag.String("imagelist", "", "name of ImageList")
-	enableProfile = flag.Bool("enable-pprof", false, "enable pprof profiling")
-	profilePort   = flag.Int("pprof-port", 6060, "port for pprof profiling. defaulted to 6060 if unspecified")
+	runtimePtr      = flag.String("runtime", "containerd", "container runtime")
+	isCustomRuntime = flag.Bool("custom-runtime", false, "assume runtime passed is local socket path")
+	imageListPtr    = flag.String("imagelist", "", "name of ImageList")
+	enableProfile   = flag.Bool("enable-pprof", false, "enable pprof profiling")
+	profilePort     = flag.Int("pprof-port", 6060, "port for pprof profiling. defaulted to 6060 if unspecified")
 
 	// Timeout  of connecting to server (default: 5m).
 	timeout  = 5 * time.Minute
@@ -61,6 +62,14 @@ func main() {
 	}
 
 	socketPath, found := util.RuntimeSocketPathMap[*runtimePtr]
+	if *isCustomRuntime {
+		socketPath = *runtimePtr
+
+		// check if socketPath exists
+		if _, err := os.Stat(socketPath); err == nil {
+			found = true
+		}
+	}
 	if !found {
 		log.Error(fmt.Errorf("unsupported runtime"), "runtime", *runtimePtr)
 		os.Exit(generalErr)


### PR DESCRIPTION
**What this PR does / why we need it**: This PR adds in a CLI flag into the manager component so that it can interpret the runtime option as a literal path.

This will allow non-standard paths (e.g. with the bundled containerd in k3s) for container runtimes to be supported

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #594 

**Special notes for your reviewer**:
