### PR TITLE
fix: add pull secrets in image list job

### DIFF
--- a/controllers/imagelist/imagelist_controller.go
+++ b/controllers/imagelist/imagelist_controller.go
@@ -270,6 +270,11 @@ func (r *Reconciler) handleImageListEvent(ctx context.Context, req *ctrl.Request
 	imageCfg := eraserContainerCfg.Image
 	image := fmt.Sprintf("%s:%s", imageCfg.Repo, imageCfg.Tag)
 
+	pullSecrets := []corev1.LocalObjectReference{}
+	for _, secret := range eraserConfig.Manager.PullSecrets {
+		pullSecrets = append(pullSecrets, corev1.LocalObjectReference{Name: secret})
+	}
+
 	jobTemplate := corev1.PodTemplateSpec{
 		Spec: corev1.PodSpec{
 			Volumes: []corev1.Volume{
@@ -280,6 +285,7 @@ func (r *Reconciler) handleImageListEvent(ctx context.Context, req *ctrl.Request
 					},
 				},
 			},
+			ImagePullSecrets:  pullSecrets,
 			RestartPolicy:     corev1.RestartPolicyNever,
 			PriorityClassName: eraserConfig.Manager.PriorityClassName,
 			Containers: []corev1.Container{


### PR DESCRIPTION
**What this PR does / why we need it**:
Image list job does not respect image pull secrets settings. It would fail to start if using private image registry.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
