### PR TITLE
ci: remove k8s 1.23 from test matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -136,7 +136,7 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          KUBERNETES_VERSION: ["1.23.13", "1.24.7", "1.25.3", "1.26.0"]
+          KUBERNETES_VERSION: ["1.24.7", "1.25.3", "1.26.0"]
           E2E_TEST: ${{ fromJson(needs.build-e2e-test-list.outputs.e2e-tests) }}
       steps:
         - name: Harden Runner


### PR DESCRIPTION
**What this PR does / why we need it**:
K8s 1.23 is EOL

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #655 

**Special notes for your reviewer**:
