### PR TITLE
fix: restore ability to catch broken scanner

### DIFF
--- a/test/e2e/tests/collector_ensure_scan/main_test.go
+++ b/test/e2e/tests/collector_ensure_scan/main_test.go
@@ -51,6 +51,8 @@ func TestMain(m *testing.M) {
 			"--set", util.ManagerImageRepo.Set(managerImage.Repo),
 			"--set", util.ManagerImageTag.Set(managerImage.Tag),
 			"--set", util.CleanupOnSuccessDelay.Set("1m"),
+			// set deleteFailedImages to FALSE to catch a broken scanner
+			"--set-json", util.ScannerConfig.Set(util.ScannerConfigNoDeleteFailedJSON),
 		),
 	).Finish(
 		envfuncs.DestroyKindCluster(util.KindClusterName),

--- a/test/e2e/util/utils.go
+++ b/test/e2e/util/utils.go
@@ -62,6 +62,7 @@ const (
 	CollectorImageRepo = HelmPath("runtimeConfig.components.collector.image.repo")
 	CollectorImageTag  = HelmPath("runtimeConfig.components.collector.image.tag")
 
+	ScannerConfig    = HelmPath("runtimeConfig.components.scanner.config")
 	ScannerEnable    = HelmPath("runtimeConfig.components.scanner.enabled")
 	ScannerImageRepo = HelmPath("runtimeConfig.components.scanner.image.repo")
 	ScannerImageTag  = HelmPath("runtimeConfig.components.scanner.image.tag")
@@ -103,6 +104,8 @@ var (
 	ParsedImages        *Images
 	Timeout             = time.Minute * 5
 	ImagePullSecretJSON = fmt.Sprintf(`["%s"]`, ImagePullSecret)
+
+	ScannerConfigNoDeleteFailedJSON = `"{ \"cacheDir\": \"/var/lib/trivy\", \"dbRepo\": \"ghcr.io/aquasecurity/trivy-db\", \"deleteFailedImages\": false, \"vulnerabilities\": null, \"ignoreUnfixed\": true, \"types\": [ \"os\", \"library\" ], \"securityChecks\": [ \"vuln\" ], \"severities\": [ \"CRITICAL\", \"HIGH\", \"MEDIUM\", \"LOW\" ] }"`
 
 	ManagerAdditionalArgs = HelmSet{
 		key:  "controllerManager.additionalArgs",


### PR DESCRIPTION
Prior to the configmap changes, there was an e2e test, `collector_ensure_scan` designed to catch when the scanner is broken. The reason this is needed is that when the scanner isn't functioning properly, and `deleteFailedImages` is set to `true`, then scanning of all images will fail.

Because in most tests we delete those images for which scanning failed, this will create a false positive: *all* images will be removed, instead of just the vulnerable ones. That makes it impossible to tell whether or not the tests should be passing, because deleting all images will remove the vulnerable images along with the safe ones.

This PR restores the test to a working state, and is critical to catch when we break the scanner.

I have manually tested and confirmed that the modified test fails when the scanner is broken.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
