### PR TITLE
ci: Fix flaking e2e test (imagelist_alias)

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -103,5 +103,5 @@ jobs:
         if: always()
         with:
           name: test_logs
-          path: ${{ github.workspace }}/test_logs/*
+          path: ${{ github.workspace }}/test_logs/
           retention-days: 1

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,6 @@ NON_VULNERABLE_IMG ?= ghcr.io/azure/non-vulnerable:latest
 E2E_TESTS ?= $(shell find ./test/e2e/tests/ -mindepth 1 -type d)
 API_VERSIONS ?= ./api/v1alpha1,./api/v1,./api/v1alpha2
 
-
-
 HELM_UPGRADE_TEST ?=
 TEST_LOGDIR ?= $(PWD)/test_logs
 
@@ -174,6 +172,7 @@ non-vulnerable-img:
 e2e-test: vulnerable-img eol-img non-vulnerable-img busybox-img
 	for test in $(E2E_TESTS); do \
 		CGO_ENABLED=0 \
+            PROJECT_ABSOLUTE_PATH=$(CURDIR) \
             REMOVER_TARBALL_PATH=${REMOVER_TARBALL_PATH} \
             MANAGER_TARBALL_PATH=${MANAGER_TARBALL_PATH} \
             COLLECTOR_TARBALL_PATH=${COLLECTOR_TARBALL_PATH} \

--- a/test/e2e/tests/collector_disable_scan/main_test.go
+++ b/test/e2e/tests/collector_disable_scan/main_test.go
@@ -26,7 +26,7 @@ func TestMain(m *testing.M) {
 	util.Testenv = env.NewWithConfig(envconf.New())
 	// Create KinD Cluster
 	util.Testenv.Setup(
-		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, "../../kind-config.yaml"),
+		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, util.KindConfigPath),
 		envfuncs.CreateNamespace(util.TestNamespace),
 		util.LoadImageToCluster(util.KindClusterName, util.ManagerImage, util.ManagerTarballPath),
 		util.LoadImageToCluster(util.KindClusterName, util.RemoverImage, util.RemoverTarballPath),

--- a/test/e2e/tests/collector_ensure_scan/main_test.go
+++ b/test/e2e/tests/collector_ensure_scan/main_test.go
@@ -27,7 +27,7 @@ func TestMain(m *testing.M) {
 	util.Testenv = env.NewWithConfig(envconf.New())
 	// Create KinD Cluster
 	util.Testenv.Setup(
-		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, "../../kind-config.yaml"),
+		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, util.KindConfigPath),
 		envfuncs.CreateNamespace(util.TestNamespace),
 		util.LoadImageToCluster(util.KindClusterName, util.ManagerImage, util.ManagerTarballPath),
 		util.LoadImageToCluster(util.KindClusterName, util.RemoverImage, util.RemoverTarballPath),

--- a/test/e2e/tests/collector_pipeline/main_test.go
+++ b/test/e2e/tests/collector_pipeline/main_test.go
@@ -27,7 +27,7 @@ func TestMain(m *testing.M) {
 	util.Testenv = env.NewWithConfig(envconf.New())
 	// Create KinD Cluster
 	util.Testenv.Setup(
-		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, "../../kind-config.yaml"),
+		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, util.KindConfigPath),
 		envfuncs.CreateNamespace(util.EraserNamespace),
 		util.LoadImageToCluster(util.KindClusterName, util.ManagerImage, util.ManagerTarballPath),
 		util.LoadImageToCluster(util.KindClusterName, util.RemoverImage, util.RemoverTarballPath),

--- a/test/e2e/tests/collector_skip_excluded/main_test.go
+++ b/test/e2e/tests/collector_skip_excluded/main_test.go
@@ -27,7 +27,7 @@ func TestMain(m *testing.M) {
 	util.Testenv = env.NewWithConfig(envconf.New())
 	// Create KinD Cluster
 	util.Testenv.Setup(
-		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, "../../kind-config.yaml"),
+		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, util.KindConfigPath),
 		envfuncs.CreateNamespace(util.TestNamespace),
 		util.LoadImageToCluster(util.KindClusterName, util.ManagerImage, util.ManagerTarballPath),
 		util.LoadImageToCluster(util.KindClusterName, util.RemoverImage, util.RemoverTarballPath),

--- a/test/e2e/tests/configmap_update/eraser_test.go
+++ b/test/e2e/tests/configmap_update/eraser_test.go
@@ -67,7 +67,7 @@ components:
 		}).
 		Assess("Deploy Imagelist", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			// deploy imagelist config
-			if err := util.DeployEraserConfig(cfg.KubeconfigFile(), cfg.Namespace(), "../../test-data", "imagelist_alpine.yaml"); err != nil {
+			if err := util.DeployEraserConfig(cfg.KubeconfigFile(), cfg.Namespace(), util.ImagelistAlpinePath); err != nil {
 				t.Error("Failed to deploy image list config", err)
 			}
 

--- a/test/e2e/tests/configmap_update/main_test.go
+++ b/test/e2e/tests/configmap_update/main_test.go
@@ -25,7 +25,7 @@ func TestMain(m *testing.M) {
 	util.Testenv = env.NewWithConfig(envconf.New())
 	// Create KinD Cluster
 	util.Testenv.Setup(
-		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, "../../kind-config.yaml"),
+		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, util.KindConfigPath),
 		envfuncs.CreateNamespace(util.TestNamespace),
 		util.LoadImageToCluster(util.KindClusterName, util.ManagerImage, util.ManagerTarballPath),
 		util.LoadImageToCluster(util.KindClusterName, util.RemoverImage, util.RemoverTarballPath),

--- a/test/e2e/tests/helm_pull_secret/main_test.go
+++ b/test/e2e/tests/helm_pull_secret/main_test.go
@@ -27,7 +27,7 @@ func TestMain(m *testing.M) {
 	util.Testenv = env.NewWithConfig(envconf.New())
 	// Create KinD Cluster
 	util.Testenv.Setup(
-		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, "../../kind-config.yaml"),
+		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, util.KindConfigPath),
 		envfuncs.CreateNamespace(util.TestNamespace),
 		util.LoadImageToCluster(util.KindClusterName, util.ManagerImage, util.ManagerTarballPath),
 		util.LoadImageToCluster(util.KindClusterName, util.RemoverImage, util.RemoverTarballPath),

--- a/test/e2e/tests/helm_pull_secret_imagelist/main_test.go
+++ b/test/e2e/tests/helm_pull_secret_imagelist/main_test.go
@@ -27,7 +27,7 @@ func TestMain(m *testing.M) {
 	util.Testenv = env.NewWithConfig(envconf.New())
 	// Create KinD Cluster
 	util.Testenv.Setup(
-		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, "../../kind-config.yaml"),
+		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, util.KindConfigPath),
 		envfuncs.CreateNamespace(util.TestNamespace),
 		util.LoadImageToCluster(util.KindClusterName, util.ManagerImage, util.ManagerTarballPath),
 		util.LoadImageToCluster(util.KindClusterName, util.RemoverImage, util.RemoverTarballPath),

--- a/test/e2e/tests/imagelist_alias/eraser_test.go
+++ b/test/e2e/tests/imagelist_alias/eraser_test.go
@@ -38,6 +38,14 @@ func TestEnsureAliasedImageRemoved(t *testing.T) {
 			// Schedule two pods on a single node. Both pods will create containers from the same image,
 			// but each pod refers to that same image by a different tag.
 			nodeName := util.GetClusterNodes(t)[0]
+
+			// At ghcr.io/azure/eraser/e2e-test/nginx there is a repository
+			// containing three tags. The three tags are `latest`, `one` and
+			// `two`. They are all aliases for the same image; only the name
+			// differs. These images are maintained there in order to avoid
+			// sideloading images into the kind cluster, which has a known bug
+			// associated with it. See https://github.com/containerd/containerd/issues/7698
+			// for more information.
 			nginxOnePod := util.NewPod(cfg.Namespace(), util.NginxAliasOne, nginxOneName, nodeName)
 			ctx = context.WithValue(ctx, nodeNameKey, nodeName)
 

--- a/test/e2e/tests/imagelist_alias/eraser_test.go
+++ b/test/e2e/tests/imagelist_alias/eraser_test.go
@@ -35,24 +35,6 @@ func TestEnsureAliasedImageRemoved(t *testing.T) {
 				t.Error("failed to pull nginx image", err)
 			}
 
-			// Create the alias nginx:one
-			_, err = util.DockerTagImage(util.NginxLatest, util.NginxAliasOne)
-			if err != nil {
-				t.Error("failed to tag nginx image", err)
-			}
-
-			// Create the alias nginx:two
-			_, err = util.DockerTagImage(util.NginxLatest, util.NginxAliasTwo)
-			if err != nil {
-				t.Error("failed to tag nginx image", err)
-			}
-
-			// Load the images into the cluster
-			_, err = util.KindLoadImage(util.KindClusterName, util.NginxAliasOne, util.NginxAliasTwo)
-			if err != nil {
-				t.Error("failed to load kind image", err)
-			}
-
 			// Schedule two pods on a single node. Both pods will create containers from the same image,
 			// but each pod refers to that same image by a different tag.
 			nodeName := util.GetClusterNodes(t)[0]

--- a/test/e2e/tests/imagelist_alias/eraser_test.go
+++ b/test/e2e/tests/imagelist_alias/eraser_test.go
@@ -62,13 +62,11 @@ func TestEnsureAliasedImageRemoved(t *testing.T) {
 			if err := cfg.Client().Resources().Create(ctx, nginxOnePod); err != nil {
 				t.Error("Failed to create the nginx pod", err)
 			}
-			ctx = context.WithValue(ctx, util.NginxAliasOne, nginxOnePod)
 
 			nginxTwoPod := util.NewPod(cfg.Namespace(), util.NginxAliasTwo, nginxTwoName, nodeName)
 			if err := cfg.Client().Resources().Create(ctx, nginxTwoPod); err != nil {
 				t.Error("Failed to create the nginx pod", err)
 			}
-			ctx = context.WithValue(ctx, util.NginxAliasTwo, nginxTwoPod)
 
 			return ctx
 		}).

--- a/test/e2e/tests/imagelist_alias/main_test.go
+++ b/test/e2e/tests/imagelist_alias/main_test.go
@@ -32,7 +32,6 @@ func TestMain(m *testing.M) {
 		envfuncs.CreateNamespace(util.TestNamespace),
 		util.LoadImageToCluster(util.KindClusterName, util.ManagerImage, util.ManagerTarballPath),
 		util.LoadImageToCluster(util.KindClusterName, util.RemoverImage, util.RemoverTarballPath),
-		util.LoadImageToCluster(util.KindClusterName, util.RemoverImage, util.RemoverTarballPath),
 		util.HelmDeployLatestEraserRelease(util.TestNamespace,
 			"--set", util.ScannerEnable.Set("false"),
 			"--set", util.CollectorEnable.Set("false"),

--- a/test/e2e/tests/imagelist_alias/main_test.go
+++ b/test/e2e/tests/imagelist_alias/main_test.go
@@ -28,7 +28,7 @@ func TestMain(m *testing.M) {
 	managerImage := util.ParsedImages.ManagerImage
 
 	util.Testenv.Setup(
-		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, "../../kind-config.yaml"),
+		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, util.KindConfigPath),
 		envfuncs.CreateNamespace(util.TestNamespace),
 		util.LoadImageToCluster(util.KindClusterName, util.ManagerImage, util.ManagerTarballPath),
 		util.LoadImageToCluster(util.KindClusterName, util.RemoverImage, util.RemoverTarballPath),

--- a/test/e2e/tests/imagelist_change/eraser_test.go
+++ b/test/e2e/tests/imagelist_change/eraser_test.go
@@ -115,7 +115,7 @@ func TestUpdateImageList(t *testing.T) {
 		}).
 		Assess("Deploy imagelist to remove nginx", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			// deploy imageJob config
-			if err := util.DeployEraserConfig(cfg.KubeconfigFile(), cfg.Namespace(), "../../test-data", "eraser_v1alpha1_imagelist.yaml"); err != nil {
+			if err := util.DeployEraserConfig(cfg.KubeconfigFile(), cfg.Namespace(), util.EraserV1Alpha1ImagelistPath); err != nil {
 				t.Error("Failed to deploy image list config", err)
 			}
 
@@ -127,7 +127,7 @@ func TestUpdateImageList(t *testing.T) {
 		}).
 		Assess("Update imagelist to prune rest of images", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			// deploy imageJob config
-			if err := util.DeployEraserConfig(cfg.KubeconfigFile(), cfg.Namespace(), "../../test-data", "eraser_v1alpha1_imagelist_updated.yaml"); err != nil {
+			if err := util.DeployEraserConfig(cfg.KubeconfigFile(), cfg.Namespace(), util.EraserV1Alpha1ImagelistUpdatedPath); err != nil {
 				t.Error("Failed to deploy image list config", err)
 			}
 

--- a/test/e2e/tests/imagelist_change/main_test.go
+++ b/test/e2e/tests/imagelist_change/main_test.go
@@ -25,7 +25,7 @@ func TestMain(m *testing.M) {
 	util.Testenv = env.NewWithConfig(envconf.New())
 	// Create KinD Cluster
 	util.Testenv.Setup(
-		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, "../../kind-config.yaml"),
+		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, util.KindConfigPath),
 		envfuncs.CreateNamespace(util.TestNamespace),
 		util.LoadImageToCluster(util.KindClusterName, util.ManagerImage, util.ManagerTarballPath),
 		util.LoadImageToCluster(util.KindClusterName, util.RemoverImage, util.RemoverTarballPath),

--- a/test/e2e/tests/imagelist_exclusion_list/eraser_test.go
+++ b/test/e2e/tests/imagelist_exclusion_list/eraser_test.go
@@ -91,7 +91,7 @@ func TestExclusionList(t *testing.T) {
 			}
 
 			// create imagelist to trigger deletion
-			if err := util.DeployEraserConfig(cfg.KubeconfigFile(), cfg.Namespace(), "../../test-data", "eraser_v1_imagelist.yaml"); err != nil {
+			if err := util.DeployEraserConfig(cfg.KubeconfigFile(), cfg.Namespace(), util.EraserV1ImagelistPath); err != nil {
 				t.Error("Failed to deploy image list config", err)
 			}
 
@@ -106,7 +106,6 @@ func TestExclusionList(t *testing.T) {
 			if err := util.GetPodLogs(t); err != nil {
 				t.Error("error getting eraser pod logs", err)
 			}
-
 
 			return ctx
 		}).

--- a/test/e2e/tests/imagelist_exclusion_list/main_test.go
+++ b/test/e2e/tests/imagelist_exclusion_list/main_test.go
@@ -25,7 +25,7 @@ func TestMain(m *testing.M) {
 	util.Testenv = env.NewWithConfig(envconf.New())
 	// Create KinD Cluster
 	util.Testenv.Setup(
-		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, "../../kind-config.yaml"),
+		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, util.KindConfigPath),
 		envfuncs.CreateNamespace(util.TestNamespace),
 		util.LoadImageToCluster(util.KindClusterName, util.ManagerImage, util.ManagerTarballPath),
 		util.LoadImageToCluster(util.KindClusterName, util.RemoverImage, util.RemoverTarballPath),

--- a/test/e2e/tests/imagelist_include_nodes/eraser_test.go
+++ b/test/e2e/tests/imagelist_include_nodes/eraser_test.go
@@ -115,7 +115,7 @@ func TestIncludeNodes(t *testing.T) {
 			}
 
 			// deploy imageJob config
-			if err = util.DeployEraserConfig(cfg.KubeconfigFile(), cfg.Namespace(), "../../test-data", "eraser_v1alpha1_imagelist.yaml"); err != nil {
+			if err = util.DeployEraserConfig(cfg.KubeconfigFile(), cfg.Namespace(), util.EraserV1Alpha1ImagelistPath); err != nil {
 				t.Error("Failed to deploy image list config", err)
 			}
 

--- a/test/e2e/tests/imagelist_include_nodes/main_test.go
+++ b/test/e2e/tests/imagelist_include_nodes/main_test.go
@@ -25,7 +25,7 @@ func TestMain(m *testing.M) {
 	util.Testenv = env.NewWithConfig(envconf.New())
 	// Create KinD Cluster
 	util.Testenv.Setup(
-		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, "../../kind-config.yaml"),
+		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, util.KindConfigPath),
 		envfuncs.CreateNamespace(util.TestNamespace),
 		util.LoadImageToCluster(util.KindClusterName, util.ManagerImage, util.ManagerTarballPath),
 		util.LoadImageToCluster(util.KindClusterName, util.RemoverImage, util.RemoverTarballPath),

--- a/test/e2e/tests/imagelist_prune_images/main_test.go
+++ b/test/e2e/tests/imagelist_prune_images/main_test.go
@@ -27,7 +27,7 @@ func TestMain(m *testing.M) {
 	util.Testenv = env.NewWithConfig(envconf.New())
 	// Create KinD Cluster
 	util.Testenv.Setup(
-		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, "../../kind-config.yaml"),
+		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, util.KindConfigPath),
 		envfuncs.CreateNamespace(util.TestNamespace),
 		util.LoadImageToCluster(util.KindClusterName, util.ManagerImage, util.ManagerTarballPath),
 		util.LoadImageToCluster(util.KindClusterName, util.RemoverImage, util.RemoverTarballPath),

--- a/test/e2e/tests/imagelist_rm_images/eraser_test.go
+++ b/test/e2e/tests/imagelist_rm_images/eraser_test.go
@@ -86,7 +86,7 @@ func TestImageListTriggersRemoverImageJob(t *testing.T) {
 			}
 
 			// deploy imageJob config
-			if err := util.DeployEraserConfig(cfg.KubeconfigFile(), cfg.Namespace(), "../../test-data", "eraser_v1alpha1_imagelist.yaml"); err != nil {
+			if err := util.DeployEraserConfig(cfg.KubeconfigFile(), cfg.Namespace(), util.EraserV1Alpha1ImagelistPath); err != nil {
 				t.Error("Failed to deploy image list config", err)
 			}
 

--- a/test/e2e/tests/imagelist_rm_images/main_test.go
+++ b/test/e2e/tests/imagelist_rm_images/main_test.go
@@ -26,7 +26,7 @@ func TestMain(m *testing.M) {
 	util.Testenv = env.NewWithConfig(envconf.New())
 	// Create KinD Cluster
 	util.Testenv.Setup(
-		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, "../../kind-config.yaml"),
+		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, util.KindConfigPath),
 		envfuncs.CreateNamespace(util.TestNamespace),
 		util.LoadImageToCluster(util.KindClusterName, util.ManagerImage, util.ManagerTarballPath),
 		util.LoadImageToCluster(util.KindClusterName, util.RemoverImage, util.RemoverTarballPath),

--- a/test/e2e/tests/imagelist_skip_nodes/eraser_test.go
+++ b/test/e2e/tests/imagelist_skip_nodes/eraser_test.go
@@ -120,7 +120,7 @@ func TestSkipNodes(t *testing.T) {
 			}
 
 			// deploy imageJob config
-			if err := util.DeployEraserConfig(cfg.KubeconfigFile(), cfg.Namespace(), util.Eraserv1Alpha1ImagelistPath); err != nil {
+			if err := util.DeployEraserConfig(cfg.KubeconfigFile(), cfg.Namespace(), util.EraserV1Alpha1ImagelistPath); err != nil {
 				t.Error("Failed to deploy image list config", err)
 			}
 

--- a/test/e2e/tests/imagelist_skip_nodes/eraser_test.go
+++ b/test/e2e/tests/imagelist_skip_nodes/eraser_test.go
@@ -120,7 +120,7 @@ func TestSkipNodes(t *testing.T) {
 			}
 
 			// deploy imageJob config
-			if err := util.DeployEraserConfig(cfg.KubeconfigFile(), cfg.Namespace(), "../../test-data", "eraser_v1alpha1_imagelist.yaml"); err != nil {
+			if err := util.DeployEraserConfig(cfg.KubeconfigFile(), cfg.Namespace(), util.Eraserv1Alpha1ImagelistPath); err != nil {
 				t.Error("Failed to deploy image list config", err)
 			}
 

--- a/test/e2e/tests/imagelist_skip_nodes/main_test.go
+++ b/test/e2e/tests/imagelist_skip_nodes/main_test.go
@@ -25,7 +25,7 @@ func TestMain(m *testing.M) {
 	util.Testenv = env.NewWithConfig(envconf.New())
 	// Create KinD Cluster
 	util.Testenv.Setup(
-		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, "../../kind-config.yaml"),
+		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, util.KindConfigPath),
 		envfuncs.CreateNamespace(util.TestNamespace),
 		util.LoadImageToCluster(util.KindClusterName, util.ManagerImage, util.ManagerTarballPath),
 		util.LoadImageToCluster(util.KindClusterName, util.RemoverImage, util.RemoverTarballPath),

--- a/test/e2e/tests/metrics_test_disable_scanner/main_test.go
+++ b/test/e2e/tests/metrics_test_disable_scanner/main_test.go
@@ -26,7 +26,7 @@ func TestMain(m *testing.M) {
 	util.Testenv = env.NewWithConfig(envconf.New())
 	// Create KinD Cluster
 	util.Testenv.Setup(
-		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, "../../kind-config.yaml"),
+		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, util.KindConfigPath),
 		envfuncs.CreateNamespace(util.TestNamespace),
 		util.DeployOtelCollector(util.TestNamespace),
 		util.LoadImageToCluster(util.KindClusterName, util.ManagerImage, util.ManagerTarballPath),

--- a/test/e2e/tests/metrics_test_eraser/eraser_test.go
+++ b/test/e2e/tests/metrics_test_eraser/eraser_test.go
@@ -23,7 +23,7 @@ func TestMetricsEraserOnly(t *testing.T) {
 	metrics := features.New("Images_removed_run_total metric should report 1").
 		Assess("Alpine image is removed", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			// deploy imagelist config
-			if err := util.DeployEraserConfig(cfg.KubeconfigFile(), cfg.Namespace(), "../../test-data", "imagelist_alpine.yaml"); err != nil {
+			if err := util.DeployEraserConfig(cfg.KubeconfigFile(), cfg.Namespace(), util.ImagelistAlpinePath); err != nil {
 				t.Error("Failed to deploy image list config", err)
 			}
 
@@ -37,7 +37,6 @@ func TestMetricsEraserOnly(t *testing.T) {
 			if err := util.GetPodLogs(t); err != nil {
 				t.Error("error getting eraser pod logs", err)
 			}
-
 
 			return ctx
 		}).

--- a/test/e2e/tests/metrics_test_eraser/main_test.go
+++ b/test/e2e/tests/metrics_test_eraser/main_test.go
@@ -25,7 +25,7 @@ func TestMain(m *testing.M) {
 	util.Testenv = env.NewWithConfig(envconf.New())
 	// Create KinD Cluster
 	util.Testenv.Setup(
-		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, "../../kind-config.yaml"),
+		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, util.KindConfigPath),
 		envfuncs.CreateNamespace(util.TestNamespace),
 		util.DeployOtelCollector(util.TestNamespace),
 		util.LoadImageToCluster(util.KindClusterName, util.ManagerImage, util.ManagerTarballPath),

--- a/test/e2e/tests/metrics_test_scanner/main_test.go
+++ b/test/e2e/tests/metrics_test_scanner/main_test.go
@@ -27,7 +27,7 @@ func TestMain(m *testing.M) {
 	util.Testenv = env.NewWithConfig(envconf.New())
 	// Create KinD Cluster
 	util.Testenv.Setup(
-		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, "../../kind-config.yaml"),
+		envfuncs.CreateKindClusterWithConfig(util.KindClusterName, util.NodeVersion, util.KindConfigPath),
 		envfuncs.CreateNamespace(util.TestNamespace),
 		util.DeployOtelCollector(util.TestNamespace),
 		util.LoadImageToCluster(util.KindClusterName, util.ManagerImage, util.ManagerTarballPath),

--- a/test/e2e/util/utils.go
+++ b/test/e2e/util/utils.go
@@ -525,13 +525,13 @@ func CheckImageRemoved(ctx context.Context, t *testing.T, nodes []string, images
 	log.WriteString("nodes: [")
 	for _, n := range nodes {
 		log.WriteString(n)
-		log.WriteRune(',')
+		log.WriteByte(',')
 	}
 	log.WriteString("]\n")
 	log.WriteString("images: [")
 	for _, i := range images {
 		log.WriteString(i)
-		log.WriteRune(',')
+		log.WriteByte(',')
 	}
 	log.WriteString("]\n")
 

--- a/test/e2e/util/utils.go
+++ b/test/e2e/util/utils.go
@@ -627,15 +627,7 @@ func DeleteStringFromSlice(strings []string, s string) []string {
 
 func DeployEraserHelm(namespace string, args ...string) env.Func {
 	return func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
-		wd, err := os.Getwd()
-		if err != nil {
-			return ctx, err
-		}
-
 		providerResourceAbsolutePath := filepath.Join(ChartPath, "eraser")
-		if err != nil {
-			return ctx, err
-		}
 
 		// start deployment
 		allArgs := []string{providerResourceAbsolutePath, "-f", HelmEmptyValuesPath}
@@ -786,7 +778,7 @@ func MakeDeploy(env map[string]string) env.Func {
 
 func DeployEraserManifest(namespace, fileName string) env.Func {
 	return func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
-		if err := DeployEraserConfig(cfg.KubeconfigFile(), namespace, DeployPath, fileName); err != nil {
+		if err := DeployEraserConfig(cfg.KubeconfigFile(), namespace, filepath.Join(DeployPath, fileName)); err != nil {
 			return ctx, err
 		}
 

--- a/test/e2e/util/utils.go
+++ b/test/e2e/util/utils.go
@@ -41,9 +41,9 @@ const (
 
 	Alpine        = "alpine"
 	Nginx         = "nginx"
-	NginxLatest   = "ghcr.io/pmengelbert/eraser/e2e-test/nginx:latest"
-	NginxAliasOne = "ghcr.io/pmengelbert/eraser/e2e-test/nginx:one"
-	NginxAliasTwo = "ghcr.io/pmengelbert/eraser/e2e-test/nginx:two"
+	NginxLatest   = "ghcr.io/azure/eraser/e2e-test/nginx:latest"
+	NginxAliasOne = "ghcr.io/azure/eraser/e2e-test/nginx:one"
+	NginxAliasTwo = "ghcr.io/azure/eraser/e2e-test/nginx:two"
 	Redis         = "redis"
 	Caddy         = "caddy"
 

--- a/test/e2e/util/utils.go
+++ b/test/e2e/util/utils.go
@@ -41,9 +41,9 @@ const (
 
 	Alpine        = "alpine"
 	Nginx         = "nginx"
-	NginxLatest   = "docker.io/library/nginx:latest"
-	NginxAliasOne = "docker.io/library/nginx:one"
-	NginxAliasTwo = "docker.io/library/nginx:two"
+	NginxLatest   = "ghcr.io/pmengelbert/eraser/e2e-test/nginx:latest"
+	NginxAliasOne = "ghcr.io/pmengelbert/eraser/e2e-test/nginx:one"
+	NginxAliasTwo = "ghcr.io/pmengelbert/eraser/e2e-test/nginx:two"
 	Redis         = "redis"
 	Caddy         = "caddy"
 

--- a/test/e2e/util/utils.go
+++ b/test/e2e/util/utils.go
@@ -521,25 +521,12 @@ func CheckDeploymentCleanedUp(ctx context.Context, t *testing.T, client klient.C
 
 func CheckImageRemoved(ctx context.Context, t *testing.T, nodes []string, images ...string) {
 	t.Helper()
-	log := new(strings.Builder)
-	log.WriteString("nodes: [")
-	for _, n := range nodes {
-		log.WriteString(n)
-		log.WriteByte(',')
-	}
-	log.WriteString("]\n")
-	log.WriteString("images: [")
-	for _, i := range images {
-		log.WriteString(i)
-		log.WriteByte(',')
-	}
-	log.WriteString("]\n")
 
 	cleaned := make(map[string]bool)
 	for len(cleaned) < len(nodes) {
 		select {
 		case <-ctx.Done():
-			t.Errorf("timeout waiting for images to be cleaned\n%s", log.String())
+			t.Error("timeout waiting for images to be cleaned")
 			return
 		default:
 		}
@@ -553,14 +540,6 @@ func CheckImageRemoved(ctx context.Context, t *testing.T, nodes []string, images
 			if err != nil {
 				t.Error("Cannot list images", err)
 			}
-			s := fmt.Sprintf(`
-----
-node: %s
-nodeImages: %s
-cleaned: %#v
-----
-            `, node, nodeImages, cleaned)
-			log.WriteString(s)
 
 			var found int
 			for _, img := range images {


### PR DESCRIPTION
**What this PR does / why we need it**:
* Use constants to avoid errors
* Don't store pod in context, the object may get stale or lose information during typecasting? I'm not sure.
* I ran this in a loop 25 times without a single failure. I will test in the CI as well.

**Miscellaneous additions**
* Use absolute paths for files in e2e tests. 

It will save us hours of time in the future

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #134 

**Special notes for your reviewer**:
🎉🎉🎉🎉🎉🎉

This was happening because of a containerd issue: https://github.com/containerd/containerd/issues/7698, which we are tracking in #483 . This will be fixed by an open PR on containerd: https://github.com/containerd/containerd/pull/7728

However, even if merged this will not fix our e2e tests, since the kind node images will likely still be using an older version of containerd.

This effectively pins the `nginx:latest image` at `nginx@sha256:480868e8c8c797794257e2abd88d0f9a8809b2fe956cbfbc05dcc0bca1f7cd43`, and pushes it to the following 3 tags:
```
    "ghcr.io/azure/eraser/e2e-test/nginx:latest",
    "ghcr.io/azure/eraser/e2e-test/nginx:one",
    "ghcr.io/azure/eraser/e2e-test/nginx:two"
``` 

Now, instead of sideloading images for the `imagelist_alias` test, we pull them from that repo. This effectively sidesteps the containerd bug.

I have tested this in the CI about 10 times, without a flake