### PR TITLE
ci: remove k8s 1.24 tests

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        KUBERNETES_VERSION: ["1.24.12", "1.25.8", "1.26.3", "1.27.1"]
+        KUBERNETES_VERSION: ["1.25.11", "1.26.6", "1.27.3"]
         E2E_TEST: ${{ fromJson(needs.build-e2e-test-list.outputs.e2e-tests) }}
     steps:
       - name: Harden Runner


### PR DESCRIPTION
**What this PR does / why we need it**:

k8s 1.24 is eol now
https://kubernetes.io/releases/patch-releases/

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
