### PR TITLE
Add k8s 1.28 to e2e test matrix

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        KUBERNETES_VERSION: ["1.25.11", "1.26.6", "1.27.3"]
+        KUBERNETES_VERSION: ["1.25.11", "1.26.6", "1.27.3", "1.28.0"]
         E2E_TEST: ${{ fromJson(needs.build-e2e-test-list.outputs.e2e-tests) }}
     steps:
       - name: Harden Runner


### PR DESCRIPTION
**What this PR does / why we need it**:
Includes k8s 1.28 in our e2e test matrix.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #842

**Special notes for your reviewer**:
The other k8s versions in our matrix are already in their latest [docker releases](https://hub.docker.com/r/kindest/node/), so they weren't bumped.