### PR TITLE
chore: update to go 1.21 and trivy 0.48.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,13 +27,12 @@ updates:
         - "version-update:semver-major"
         - "version-update:semver-minor"
 
-
   - package-ecosystem: docker
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
 
   - package-ecosystem: docker
     directory: /build/tooling
     schedule:
-      interval: daily
+      interval: weekly

--- a/.github/workflows/e2e-build.yaml
+++ b/.github/workflows/e2e-build.yaml
@@ -17,10 +17,11 @@ jobs:
         uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423
         with:
           egress-policy: audit
-      - name: Set up Go 1.20
+      - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "1.20"
+          go-version: "1.21"
+          check-latest: true
       - name: Setup buildx instance
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
         with:
@@ -58,10 +59,11 @@ jobs:
         uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423
         with:
           egress-policy: audit
-      - name: Set up Go 1.20
+      - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "1.20"
+          go-version: "1.21"
+          check-latest: true
       - name: Setup buildx instance
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
         with:
@@ -98,10 +100,11 @@ jobs:
         uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423
         with:
           egress-policy: audit
-      - name: Set up Go 1.20
+      - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "1.20"
+          go-version: "1.21"
+          check-latest: true
       - name: Setup buildx instance
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
         with:
@@ -138,10 +141,11 @@ jobs:
         uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423
         with:
           egress-policy: audit
-      - name: Set up Go 1.20
+      - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "1.20"
+          go-version: "1.21"
+          check-latest: true
       - name: Setup buildx instance
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
         with:

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -57,10 +57,11 @@ jobs:
         with:
           name: ${{ inputs.bucket-id }}
           path: ${{ github.workspace }}/images
-      - name: Set up Go 1.20
+      - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "1.20"
+          go-version: "1.21"
+          check-latest: true
       - name: Set env
         run: |
           ARCHIVE_DIR=${{ github.workspace }}/images

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -22,10 +22,11 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Set up Go 1.20
+      - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "1.20"
+          go-version: "1.21"
+          check-latest: true
 
       - name: Set release version and target branch for vNext
         if: github.event_name == 'push'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,10 +49,11 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Set up Go 1.20
+      - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "1.20"
+          go-version: "1.21"
+          check-latest: true
       - name: lint manager
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
@@ -89,10 +90,11 @@ jobs:
         uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423
         with:
           egress-policy: audit
-      - name: Set up Go 1.20
+      - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "1.20"
+          go-version: "1.21"
+          check-latest: true
       - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
           key: ${{ runner.OS }}-go-${{ hashFiles('**/go.sum') }}
@@ -123,10 +125,11 @@ jobs:
           egress-policy: audit
       - name: Check out code into the Go module directory
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Set up Go 1.20
+      - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "1.20"
+          go-version: "1.21"
+          check-latest: true
       - name: Check go.mod and manifests
         run: |
           go mod tidy

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,7 +14,7 @@ linters-settings:
   misspell:
     locale: US
   staticcheck:
-    go: "1.20"
+    go: "1.21"
 
 linters:
   disable-all: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 # syntax=docker/dockerfile:1.6
+
+# Default Trivy binary image, overwritten by Makefile
 ARG TRIVY_BINARY_IMG="ghcr.io/aquasecurity/trivy:0.48.3"
 ARG BUILDKIT_SBOM_SCAN_STAGE=builder,manager-build,collector-build,remover-build,trivy-scanner-build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # syntax=docker/dockerfile:1.6
+ARG TRIVY_BINARY_IMG="ghcr.io/aquasecurity/trivy:0.48.3"
 ARG BUILDKIT_SBOM_SCAN_STAGE=builder,manager-build,collector-build,remover-build,trivy-scanner-build
 
-FROM --platform=$TARGETPLATFORM ghcr.io/aquasecurity/trivy:0.48.3 AS trivy-binary
+FROM --platform=$TARGETPLATFORM $TRIVY_BINARY_IMG AS trivy-binary
 
 # Build the manager binary
 FROM --platform=$BUILDPLATFORM golang:1.21-bookworm AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,10 @@
 # syntax=docker/dockerfile:1.6
-
-ARG BUILDERIMAGE="golang:1.20-bullseye"
-ARG TRIVY_BINARY_IMG="ghcr.io/aquasecurity/trivy:0.45.1"
-ARG STATICBASEIMAGE="gcr.io/distroless/static:latest"
-ARG STATICNONROOTBASEIMAGE="gcr.io/distroless/static:nonroot"
 ARG BUILDKIT_SBOM_SCAN_STAGE=builder,manager-build,collector-build,remover-build,trivy-scanner-build
 
-FROM --platform=$TARGETPLATFORM $TRIVY_BINARY_IMG AS trivy-binary
+FROM --platform=$TARGETPLATFORM ghcr.io/aquasecurity/trivy:0.48.3 AS trivy-binary
 
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM $BUILDERIMAGE AS builder
+FROM --platform=$BUILDPLATFORM golang:1.21-bookworm AS builder
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -52,25 +47,25 @@ RUN \
     --mount=type=cache,target=/go/pkg/mod \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build ${LDFLAGS:+-ldflags "$LDFLAGS"} -o out/trivy-scanner ./pkg/scanners/trivy
 
-FROM --platform=$TARGETPLATFORM $STATICNONROOTBASEIMAGE AS manager
+FROM --platform=$TARGETPLATFORM gcr.io/distroless/static:nonroot AS manager
 WORKDIR /
 COPY --from=manager-build /workspace/out/manager .
 USER 65532:65532
 ENTRYPOINT ["/manager"]
 
-FROM --platform=$TARGETPLATFORM $STATICBASEIMAGE as collector
+FROM --platform=$TARGETPLATFORM gcr.io/distroless/static:latest as collector
 COPY --from=collector-build /workspace/out/collector /
 ENTRYPOINT ["/collector"]
 
-FROM --platform=$TARGETPLATFORM $STATICBASEIMAGE as remover
+FROM --platform=$TARGETPLATFORM gcr.io/distroless/static:latest as remover
 COPY --from=remover-build /workspace/out/remover /
 ENTRYPOINT ["/remover"]
 
-FROM --platform=$TARGETPLATFORM $STATICBASEIMAGE as trivy-scanner
+FROM --platform=$TARGETPLATFORM gcr.io/distroless/static:latest as trivy-scanner
 COPY --from=trivy-scanner-build /workspace/out/trivy-scanner /
 COPY --from=trivy-binary /usr/local/bin/trivy /
 WORKDIR /var/lib/trivy
 ENTRYPOINT ["/trivy-scanner"]
 
-FROM $STATICNONROOTBASEIMAGE as non-vulnerable
+FROM gcr.io/distroless/static:nonroot as non-vulnerable
 COPY --from=builder /tmp /tmp

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,7 @@ REMOVER_TAG ?= ${VERSION}
 # Image URL to use all building/pushing image targets
 TRIVY_SCANNER_REPO ?= ghcr.io/eraser-dev/eraser-trivy-scanner
 TRIVY_SCANNER_IMG ?= ${TRIVY_SCANNER_REPO}:${TRIVY_SCANNER_TAG}
-TRIVY_BINARY_REPO ?= ghcr.io/aquasecurity/trivy
-TRIVY_BINARY_TAG ?= 0.45.1
-TRIVY_BINARY_IMG ?= ${TRIVY_BINARY_REPO}:${TRIVY_BINARY_TAG}
+TRIVY_BINARY_VERSION ?= 0.48.3
 MANAGER_REPO ?= ghcr.io/eraser-dev/eraser-manager
 MANAGER_IMG ?= ${MANAGER_REPO}:${MANAGER_TAG}
 REMOVER_REPO ?= ghcr.io/eraser-dev/remover
@@ -43,7 +41,7 @@ PLATFORM ?= linux
 # build variables
 LDFLAGS ?= $(shell build/version.sh "${VERSION}")
 ERASER_LDFLAGS ?= -extldflags=-static $(LDFLAGS) -w
-TRIVY_SCANNER_LDFLAGS ?= $(ERASER_LDFLAGS) -X 'main.trivyVersion=v$(TRIVY_BINARY_TAG)'
+TRIVY_SCANNER_LDFLAGS ?= $(ERASER_LDFLAGS) -X 'main.trivyVersion=v$(TRIVY_BINARY_VERSION)'
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -222,7 +220,6 @@ docker-build-trivy-scanner: ## Build docker image for trivy-scanner image.
 	docker buildx build \
 		$(_CACHE_FROM) $(_CACHE_TO) \
 		$(_ATTESTATIONS) \
-		--build-arg TRIVY_BINARY_IMG="$(TRIVY_BINARY_IMG)" \
 		--build-arg LDFLAGS="$(TRIVY_SCANNER_LDFLAGS)" \
 		--platform="$(PLATFORM)" \
 		--output=$(OUTPUT_TYPE) \

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,9 @@ REMOVER_TAG ?= ${VERSION}
 # Image URL to use all building/pushing image targets
 TRIVY_SCANNER_REPO ?= ghcr.io/eraser-dev/eraser-trivy-scanner
 TRIVY_SCANNER_IMG ?= ${TRIVY_SCANNER_REPO}:${TRIVY_SCANNER_TAG}
-TRIVY_BINARY_VERSION ?= 0.48.3
+TRIVY_BINARY_REPO ?= ghcr.io/aquasecurity/trivy
+TRIVY_BINARY_TAG ?= 0.48.3
+TRIVY_BINARY_IMG ?= ${TRIVY_BINARY_REPO}:${TRIVY_BINARY_TAG}
 MANAGER_REPO ?= ghcr.io/eraser-dev/eraser-manager
 MANAGER_IMG ?= ${MANAGER_REPO}:${MANAGER_TAG}
 REMOVER_REPO ?= ghcr.io/eraser-dev/remover
@@ -41,7 +43,7 @@ PLATFORM ?= linux
 # build variables
 LDFLAGS ?= $(shell build/version.sh "${VERSION}")
 ERASER_LDFLAGS ?= -extldflags=-static $(LDFLAGS) -w
-TRIVY_SCANNER_LDFLAGS ?= $(ERASER_LDFLAGS) -X 'main.trivyVersion=v$(TRIVY_BINARY_VERSION)'
+TRIVY_SCANNER_LDFLAGS ?= $(ERASER_LDFLAGS) -X 'main.trivyVersion=v$(TRIVY_BINARY_TAG)'
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -226,6 +228,7 @@ docker-build-trivy-scanner: ## Build docker image for trivy-scanner image.
 	docker buildx build \
 		$(_CACHE_FROM) $(_CACHE_TO) \
 		$(_ATTESTATIONS) \
+		--build-arg TRIVY_BINARY_IMG="$(TRIVY_BINARY_IMG)" \
 		--build-arg LDFLAGS="$(TRIVY_SCANNER_LDFLAGS)" \
 		--platform="$(PLATFORM)" \
 		--output=$(OUTPUT_TYPE) \


### PR DESCRIPTION
**What this PR does / why we need it**:
- update go to 1.21
- update trivy to 0.48.2
- move base images inline so dependabot will pin and bump

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
