### PR TITLE
chore: update download and upload artifact to latest

### DIFF
--- a/.github/workflows/e2e-build.yaml
+++ b/.github/workflows/e2e-build.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6  # v4.2.0
         with:
-          name: ${{ inputs.bucket-id }}
+          name: ${{ inputs.bucket-id }}-remover
           path: remover_test.tar
           overwrite: true
 
@@ -89,7 +89,7 @@ jobs:
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6  # v4.2.0
         with:
-          name: ${{ inputs.bucket-id }}
+          name: ${{ inputs.bucket-id }}-scanner
           path: scanner_test.tar
           overwrite: true
 
@@ -131,7 +131,7 @@ jobs:
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6  # v4.2.0
         with:
-          name: ${{ inputs.bucket-id }}
+          name: ${{ inputs.bucket-id }}-manager
           path: manager_test.tar
           overwrite: true
 
@@ -173,6 +173,6 @@ jobs:
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6  # v4.2.0
         with:
-          name: ${{ inputs.bucket-id }}
+          name: ${{ inputs.bucket-id }}-collector
           path: collector_test.tar
           overwrite: true

--- a/.github/workflows/e2e-build.yaml
+++ b/.github/workflows/e2e-build.yaml
@@ -45,10 +45,11 @@ jobs:
       - name: Build remover
         run: 'make docker-build-remover OUTPUT_TYPE=type=oci,dest=./${REMOVER_REPO}_${REMOVER_TAG}.tar,name=${REMOVER_REPO}:${REMOVER_TAG}'
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6  # v4.2.0
         with:
           name: ${{ inputs.bucket-id }}
           path: remover_test.tar
+          overwrite: true
 
   build-trivy-scanner:
     name: "Build trivy-scanner image for e2e tests"
@@ -86,10 +87,11 @@ jobs:
       - name: Build trivy-scanner
         run: 'make docker-build-trivy-scanner OUTPUT_TYPE=type=oci,dest=./${TRIVY_SCANNER_REPO}_${TRIVY_SCANNER_TAG}.tar,name=${TRIVY_SCANNER_REPO}:${TRIVY_SCANNER_TAG}'
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6  # v4.2.0
         with:
           name: ${{ inputs.bucket-id }}
           path: scanner_test.tar
+          overwrite: true
 
   build-manager:
     name: "Build manager image for e2e tests"
@@ -127,10 +129,11 @@ jobs:
       - name: Build manager
         run: 'make docker-build-manager OUTPUT_TYPE=type=oci,dest=./${MANAGER_REPO}_${MANAGER_TAG}.tar,name=${MANAGER_REPO}:${MANAGER_TAG}'
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6  # v4.2.0
         with:
           name: ${{ inputs.bucket-id }}
           path: manager_test.tar
+          overwrite: true
 
   build-collector:
     name: "Build collector image for e2e tests"
@@ -168,7 +171,8 @@ jobs:
       - name: Build collector
         run: 'make docker-build-collector OUTPUT_TYPE=type=oci,dest=./${COLLECTOR_REPO}_${COLLECTOR_TAG}.tar,name=${COLLECTOR_REPO}:${COLLECTOR_TAG}'
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6  # v4.2.0
         with:
           name: ${{ inputs.bucket-id }}
           path: collector_test.tar
+          overwrite: true

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -57,6 +57,7 @@ jobs:
         with:
           name: ${{ inputs.bucket-id }}
           path: ${{ github.workspace }}/images
+          merge-multiple: true
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Fetch Build Artifacts
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
         with:
           name: ${{ inputs.bucket-id }}
           path: ${{ github.workspace }}/images
@@ -100,9 +100,10 @@ jobs:
             KUBERNETES_VERSION=${{ matrix.KUBERNETES_VERSION }} \
             E2E_TESTS=${{ matrix.E2E_TEST }}
       - name: Upload artifacts
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6  # v4.2.0
         if: always()
         with:
           name: test_logs
           path: ${{ github.workspace }}/test_logs/
           retention-days: 1
+          overwrite: true

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Fetch Build Artifacts
         uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
         with:
-          name: ${{ inputs.bucket-id }}
+          pattern: ${{ inputs.bucket-id }}-*
           path: ${{ github.workspace }}/images
           merge-multiple: true
       - name: Set up Go

--- a/.github/workflows/scan-images.yaml
+++ b/.github/workflows/scan-images.yaml
@@ -87,6 +87,7 @@ jobs:
         with:
           name: ${{ matrix.image }} Scan Results
           path: ${{ matrix.image }}-results.sarif
+          merge-multiple: true
 
       - name: Upload results to GitHub Security
         uses: github/codeql-action/upload-sarif@798e74c57dbcad53929892efdf30dfafe12c8c37 # v2.14.4

--- a/.github/workflows/scan-images.yaml
+++ b/.github/workflows/scan-images.yaml
@@ -59,10 +59,11 @@ jobs:
           format: 'sarif'
           output: ${{ matrix.data.image }}-results.sarif
 
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      - uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6  # v4.2.0
         with:
           name: ${{ matrix.data.image }} Scan Results
           path: ${{ matrix.data.image }}-results.sarif
+          overwrite: true
 
   upload_vulnerabilities:
     name: Upload ${{ matrix.image }} results to GitHub Security
@@ -82,7 +83,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
         with:
           name: ${{ matrix.image }} Scan Results
           path: ${{ matrix.image }}-results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -57,11 +57,12 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6  # v4.2.0
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
+          overwrite: true
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates download and upload artifact to latest. Upload and Download artifact have to be set to the same major version. Upload artifact cut a new release following v4.1.0 that adds ability to overwrite an artifact (https://github.com/actions/upload-artifact/releases) which was throwing an error in PR #954. v4 also doesn't allow mutable artifacts so we have to give each (collector, remover, manager, scanner) a unique name.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
