### PR TITLE
Harden scanner extra volume handling

### DIFF
--- a/controllers/imagecollector/imagecollector_controller.go
+++ b/controllers/imagecollector/imagecollector_controller.go
@@ -57,8 +57,9 @@ import (
 )
 
 const (
-	ownerLabelValue  = "imagecollector"
-	configVolumeName = "eraser-config"
+	ownerLabelValue           = "imagecollector"
+	configVolumeName          = "eraser-config"
+	scannerExtraVolumeBaseDir = "/run/eraser.sh/scanner-extra"
 )
 
 var (
@@ -452,20 +453,22 @@ func (r *Reconciler) createImageJob(ctx context.Context) (ctrl.Result, error) {
 		log.Info("extra mount for scanner starts")
 		scannerVolumes := compCfg.Scanner.Volumes
 		if len(scannerVolumes) != 0 {
-			jobTemplate.Spec.Volumes = append(jobTemplate.Spec.Volumes, scannerVolumes...)
+			allowedScannerVolumes := []corev1.Volume{}
 			scannerVolumeMounts := []corev1.VolumeMount{}
 			for idx := range scannerVolumes {
 				volume := scannerVolumes[idx]
-				if volume.HostPath == nil {
-					log.Error(fmt.Errorf("volume hostPath is nil"), "invalid volume", "volumeName", volume.Name)
+				if volume.HostPath != nil {
+					log.Error(fmt.Errorf("hostPath volumes are not allowed"), "invalid scanner volume", "volumeName", volume.Name, "hostPath", volume.HostPath.Path)
 					continue
 				}
+				allowedScannerVolumes = append(allowedScannerVolumes, volume)
 				scannerVolumeMounts = append(scannerVolumeMounts, corev1.VolumeMount{
 					Name:      volume.Name,
-					MountPath: volume.HostPath.Path,
+					MountPath: filepath.Join(scannerExtraVolumeBaseDir, volume.Name),
 					ReadOnly:  true,
 				})
 			}
+			jobTemplate.Spec.Volumes = append(jobTemplate.Spec.Volumes, allowedScannerVolumes...)
 			scannerContainer.VolumeMounts = append(scannerContainer.VolumeMounts, scannerVolumeMounts...)
 		}
 


### PR DESCRIPTION
### Motivation
- The manager config previously allowed `components.scanner.volumes` to include `hostPath` volumes which were mounted into the scanner container at the host path, enabling disclosure of host filesystem data if the ConfigMap could be modified.

### Description
- Reject `hostPath`-backed volumes from `components.scanner.volumes` by logging an error and skipping them to prevent arbitrary hostPath mounts into the scanner container.
- Introduce a fixed internal base directory `"/run/eraser.sh/scanner-extra"` and mount accepted non-`hostPath` extra volumes under `"/run/eraser.sh/scanner-extra/<volume-name>"` as read-only to avoid mirroring host paths.
- Only validated (non-`hostPath`) volumes are appended to the job template's `Spec.Volumes` and mounted into the scanner container; changes are localized to `controllers/imagecollector/imagecollector_controller.go`.

### Testing
- Ran `go test -run TestDoesNotExist ./controllers/imagecollector`, which completed (package has no test files).
- Ran `go test ./api/unversioned/...`, which completed (packages have no test files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d70f77151c832aa5aaafbb6b0c35d7)