### PR TITLE
fix: use --pkg-types instead of deprecated --vuln-type for trivy

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,26 +57,26 @@ jobs:
       - name: lint manager
         uses: golangci/golangci-lint-action@e7fa5ac41e1cf5b7d48e45e42232ce7ada589601 # v9.1.0
         with:
-          version: latest
+          version: v2.12.2
           args: --timeout=10m
       - name: lint remover
         uses: golangci/golangci-lint-action@e7fa5ac41e1cf5b7d48e45e42232ce7ada589601 # v9.1.0
         with:
-          version: latest
+          version: v2.12.2
           working-directory: pkg/remover
           skip-pkg-cache: true
           args: --timeout=10m
       - name: lint collector
         uses: golangci/golangci-lint-action@e7fa5ac41e1cf5b7d48e45e42232ce7ada589601 # v9.1.0
         with:
-          version: latest
+          version: v2.12.2
           working-directory: pkg/collector
           skip-pkg-cache: true
           args: --timeout=10m
       - name: lint trivvy scanner
         uses: golangci/golangci-lint-action@e7fa5ac41e1cf5b7d48e45e42232ce7ada589601 # v9.1.0
         with:
-          version: latest
+          version: v2.12.2
           working-directory: pkg/scanners/trivy
           skip-pkg-cache: true
           args: --timeout=10m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,6 +21,9 @@ linters:
     - unused
     - whitespace
   settings:
+    goconst:
+      # Keep test expectations independent from production constants.
+      ignore-tests: true
     gocritic:
       enabled-tags:
       - performance

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ KUSTOMIZE_VERSION ?= 3.8.9
 KUBERNETES_VERSION ?= 1.29.2
 NODE_VERSION ?= 20-bullseye-slim
 ENVTEST_K8S_VERSION ?= 1.25
-GOLANGCI_LINT_VERSION := 1.43.0
+GOLANGCI_LINT_VERSION := 2.12.2
 
 PLATFORM ?= linux
 
@@ -75,13 +75,14 @@ TOOLS_BIN_DIR := $(abspath $(TOOLS_DIR)/bin)
 GO_INSTALL := ./hack/go-install.sh
 
 GOLANGCI_LINT_BIN := golangci-lint
+GOLANGCI_LINT_MODULE := github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 GOLANGCI_LINT := $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN)-v$(GOLANGCI_LINT_VERSION)
 
 TEST_COUNT ?= 1
 TIMEOUT ?= 1800s
 
 $(GOLANGCI_LINT):
-	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) github.com/golangci/golangci-lint/cmd/golangci-lint $(GOLANGCI_LINT_BIN) v$(GOLANGCI_LINT_VERSION)
+	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) $(GOLANGCI_LINT_MODULE) $(GOLANGCI_LINT_BIN) v$(GOLANGCI_LINT_VERSION)
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.

--- a/controllers/imagecollector/imagecollector_controller.go
+++ b/controllers/imagecollector/imagecollector_controller.go
@@ -57,8 +57,10 @@ import (
 )
 
 const (
-	ownerLabelValue  = "imagecollector"
-	configVolumeName = "eraser-config"
+	ownerLabelValue      = "imagecollector"
+	configVolumeName     = "eraser-config"
+	sharedDataVolumeName = "shared-data"
+	sharedDataMountPath  = "/run/eraser.sh/shared-data"
 )
 
 var (
@@ -328,7 +330,7 @@ func (r *Reconciler) createImageJob(ctx context.Context) (ctrl.Result, error) {
 			Volumes: []corev1.Volume{
 				{
 					// EmptyDir default
-					Name: "shared-data",
+					Name: sharedDataVolumeName,
 				},
 				{
 					Name: configVolumeName,
@@ -351,15 +353,15 @@ func (r *Reconciler) createImageJob(ctx context.Context) (ctrl.Result, error) {
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Args:            collArgs,
 					VolumeMounts: []corev1.VolumeMount{
-						{MountPath: "/run/eraser.sh/shared-data", Name: "shared-data"},
+						{MountPath: sharedDataMountPath, Name: sharedDataVolumeName},
 					},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							"cpu":    collectorCfg.Request.CPU,
-							"memory": collectorCfg.Request.Mem,
+							corev1.ResourceCPU:    collectorCfg.Request.CPU,
+							corev1.ResourceMemory: collectorCfg.Request.Mem,
 						},
 						Limits: corev1.ResourceList{
-							"memory": collectorCfg.Limit.Mem,
+							corev1.ResourceMemory: collectorCfg.Limit.Mem,
 						},
 					},
 				},
@@ -369,15 +371,15 @@ func (r *Reconciler) createImageJob(ctx context.Context) (ctrl.Result, error) {
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Args:            removerArgs,
 					VolumeMounts: []corev1.VolumeMount{
-						{MountPath: "/run/eraser.sh/shared-data", Name: "shared-data"},
+						{MountPath: sharedDataMountPath, Name: sharedDataVolumeName},
 					},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							"cpu":    eraserCfg.Request.CPU,
-							"memory": eraserCfg.Request.Mem,
+							corev1.ResourceCPU:    eraserCfg.Request.CPU,
+							corev1.ResourceMemory: eraserCfg.Request.Mem,
 						},
 						Limits: corev1.ResourceList{
-							"memory": eraserCfg.Limit.Mem,
+							corev1.ResourceMemory: eraserCfg.Limit.Mem,
 						},
 					},
 					SecurityContext: eraserUtils.SharedSecurityContext,
@@ -420,16 +422,16 @@ func (r *Reconciler) createImageJob(ctx context.Context) (ctrl.Result, error) {
 			Image: scannerImg,
 			Args:  scannerArgs,
 			VolumeMounts: []corev1.VolumeMount{
-				{MountPath: "/run/eraser.sh/shared-data", Name: "shared-data"},
+				{MountPath: sharedDataMountPath, Name: sharedDataVolumeName},
 				{MountPath: cfgDirname, Name: configVolumeName},
 			},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					"memory": scanCfg.Request.Mem,
-					"cpu":    scanCfg.Request.CPU,
+					corev1.ResourceMemory: scanCfg.Request.Mem,
+					corev1.ResourceCPU:    scanCfg.Request.CPU,
 				},
 				Limits: corev1.ResourceList{
-					"memory": scanCfg.Limit.Mem,
+					corev1.ResourceMemory: scanCfg.Limit.Mem,
 				},
 			},
 			// env vars for exporting metrics

--- a/pkg/scanners/trivy/types.go
+++ b/pkg/scanners/trivy/types.go
@@ -31,7 +31,7 @@ const (
 	trivyTimeoutFlag        = "--timeout"
 	trivyDBRepoFlag         = "--db-repository"
 	trivyIgnoreUnfixedFlag  = "--ignore-unfixed"
-	trivyVulnTypesFlag      = "--vuln-type"
+	trivyPkgTypesFlag       = "--pkg-types"
 	trivySecurityChecksFlag = "--scanners"
 	trivySeveritiesFlag     = "--severity"
 	trivyRuntimeFlag        = "--image-src"
@@ -127,8 +127,8 @@ func (c *Config) cliArgs(ref string) []string {
 	}
 
 	if len(c.Vulnerabilities.Types) > 0 {
-		allVulnTypes := strings.Join(c.Vulnerabilities.Types, ",")
-		args = append(args, trivyVulnTypesFlag, allVulnTypes)
+		allPkgTypes := strings.Join(c.Vulnerabilities.Types, ",")
+		args = append(args, trivyPkgTypesFlag, allPkgTypes)
 	}
 
 	if len(c.Vulnerabilities.SecurityChecks) > 0 {

--- a/pkg/scanners/trivy/types_test.go
+++ b/pkg/scanners/trivy/types_test.go
@@ -66,7 +66,7 @@ func TestCLIArgs(t *testing.T) {
 		{
 			desc:     "specify vulnerability types",
 			config:   Config{Vulnerabilities: VulnConfig{Types: []string{"library", "os"}}},
-			expected: []string{"--format=json", "image", "--image-src", ImgSrcContainerd, "--vuln-type", "library,os", ref},
+			expected: []string{"--format=json", "image", "--image-src", ImgSrcContainerd, "--pkg-types", "library,os", ref},
 		},
 		{
 			desc:     "specify security checks / scanners",
@@ -117,7 +117,7 @@ func TestCLIArgs(t *testing.T) {
 			},
 			expected: []string{
 				"--format=json", "image", "--image-src", ImgSrcPodman, "--db-repository", "example.test/db/repo", "--ignore-unfixed",
-				"--vuln-type", "library,os", "--scanners", "license,vuln", "--severity", "LOW,MEDIUM", "--ignore-status", "unknown,fixed", ref,
+				"--pkg-types", "library,os", "--scanners", "license,vuln", "--severity", "LOW,MEDIUM", "--ignore-status", "unknown,fixed", ref,
 			},
 		},
 		{
@@ -140,7 +140,7 @@ func TestCLIArgs(t *testing.T) {
 			},
 			expected: []string{
 				"--format=json", "--cache-dir", "/var/lib/trivy", "--timeout", "1m40s", "image", "--image-src", ImgSrcPodman,
-				"--db-repository", "example.test/db/repo", "--ignore-unfixed", "--vuln-type", "os", "--scanners",
+				"--db-repository", "example.test/db/repo", "--ignore-unfixed", "--pkg-types", "os", "--scanners",
 				"license,vuln", "--severity", "CRITICAL", "--ignore-status", "unknown,fixed", ref,
 			},
 		},

--- a/test/e2e/util/kubectl.go
+++ b/test/e2e/util/kubectl.go
@@ -25,7 +25,7 @@ func KubectlApply(kubeconfigPath, namespace string, args []string) error {
 func HelmInstall(kubeconfigPath, namespace string, args []string) error {
 	args = append([]string{
 		"install",
-		"eraser-e2e-test",
+		KindClusterName,
 		"--wait",
 		"--debug",
 		"--create-namespace",
@@ -41,7 +41,7 @@ func HelmInstall(kubeconfigPath, namespace string, args []string) error {
 func HelmUpgrade(kubeconfigPath, namespace string, args []string) error {
 	args = append([]string{
 		"upgrade",
-		"eraser-e2e-test",
+		KindClusterName,
 		"--wait",
 		"--debug",
 		fmt.Sprintf("--kubeconfig=%s", kubeconfigPath),
@@ -56,7 +56,7 @@ func HelmUpgrade(kubeconfigPath, namespace string, args []string) error {
 func HelmUninstall(kubeconfigPath, namespace string, args []string) error {
 	args = append([]string{
 		"uninstall",
-		"eraser-e2e-test",
+		KindClusterName,
 		fmt.Sprintf("--kubeconfig=%s", kubeconfigPath),
 		fmt.Sprintf("--namespace=%s", namespace),
 	}, args...)
@@ -79,7 +79,7 @@ func KubectlDelete(kubeconfigPath, namespace string, args []string) error {
 
 func KubectlExecCurl(kubeconfigPath, podName string, endpoint, namespace string) (string, error) {
 	args := []string{
-		"exec",
+		execSubcommand,
 		"-i",
 		podName,
 		"-n",
@@ -172,6 +172,7 @@ func KubectlGet(kubeconfigPath string, otherArgs ...string) (string, error) {
 func Kubectl(args []string) (string, error) {
 	klog.Infof("kubectl %s", strings.Join(args, " "))
 
+	//nolint:gosec // G204: This e2e helper intentionally forwards trusted test arguments to kubectl.
 	cmd := exec.Command("kubectl", args...)
 
 	stdoutStderr, err := cmd.CombinedOutput()
@@ -186,6 +187,7 @@ func Kubectl(args []string) (string, error) {
 func KubectlBackground(args []string) error {
 	klog.Infof("kubectl %s", strings.Join(args, " "))
 
+	//nolint:gosec // G204: This e2e helper intentionally forwards trusted test arguments to kubectl.
 	cmd := exec.Command("kubectl", args...)
 
 	if err := cmd.Start(); err != nil {
@@ -198,6 +200,7 @@ func KubectlBackground(args []string) error {
 func Helm(args []string) (string, error) {
 	klog.Infof("helm %s", strings.Join(args, " "))
 
+	//nolint:gosec // G204: This e2e helper intentionally forwards trusted test arguments to helm.
 	cmd := exec.Command("helm", args...)
 
 	stdoutStderr, err := cmd.CombinedOutput()

--- a/test/e2e/util/utils.go
+++ b/test/e2e/util/utils.go
@@ -35,6 +35,8 @@ const (
 	providerResourceChartDir  = "manifest_staging/charts"
 	providerResourceDeployDir = "manifest_staging/deploy"
 	publishedHelmRepo         = "https://eraser-dev.github.io/eraser/charts"
+	eraserControllerManager   = "eraser-controller-manager"
+	execSubcommand            = "exec"
 
 	KindClusterName  = "eraser-e2e-test"
 	ProviderResource = "eraser.yaml"
@@ -292,7 +294,7 @@ func HelmDeployLatestEraserRelease(namespace string, extraArgs ...string) env.Fu
 
 		// wait for the deployment to finish becoming available
 		eraserManagerDep := appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{Name: "eraser-controller-manager", Namespace: namespace},
+			ObjectMeta: metav1.ObjectMeta{Name: eraserControllerManager, Namespace: namespace},
 		}
 
 		if err := wait.For(conditions.New(client.Resources()).DeploymentConditionMatch(&eraserManagerDep, appsv1.DeploymentAvailable, corev1.ConditionTrue),
@@ -431,7 +433,7 @@ func GetImageJob(ctx context.Context, cfg *envconf.Config) (eraserv1.ImageJob, e
 
 func ListNodeContainers(nodeName string) (string, error) {
 	args := []string{
-		"exec",
+		execSubcommand,
 		nodeName,
 		"ctr",
 		"-n",
@@ -453,7 +455,7 @@ func ListNodeContainers(nodeName string) (string, error) {
 
 func ListNodeImages(nodeName string) (string, error) {
 	args := []string{
-		"exec",
+		execSubcommand,
 		nodeName,
 		"ctr",
 		"-n",
@@ -647,7 +649,7 @@ func DeployEraserHelm(namespace string, args ...string) env.Func {
 
 		// wait for the deployment to finish becoming available
 		eraserManagerDep := appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{Name: "eraser-controller-manager", Namespace: namespace},
+			ObjectMeta: metav1.ObjectMeta{Name: eraserControllerManager, Namespace: namespace},
 		}
 
 		if err = wait.For(conditions.New(client.Resources()).DeploymentConditionMatch(&eraserManagerDep, appsv1.DeploymentAvailable, corev1.ConditionTrue),
@@ -684,7 +686,7 @@ func UpgradeEraserHelm(namespace string, args ...string) env.Func {
 
 		// wait for the deployment to finish becoming available
 		eraserManagerDep := appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{Name: "eraser-controller-manager", Namespace: namespace},
+			ObjectMeta: metav1.ObjectMeta{Name: eraserControllerManager, Namespace: namespace},
 		}
 
 		if err = wait.For(conditions.New(client.Resources()).DeploymentConditionMatch(&eraserManagerDep, appsv1.DeploymentAvailable, corev1.ConditionTrue),

--- a/third_party/open-policy-agent/gatekeeper/helmify/main.go
+++ b/third_party/open-policy-agent/gatekeeper/helmify/main.go
@@ -110,6 +110,7 @@ func copyStaticFiles(root string, subdirs ...string) error {
 				return err
 			}
 			fmt.Printf("Writing %s\n", destination)
+			//nolint:gosec // G703: destination only adds base names read from the repository-controlled static tree.
 			if err := os.WriteFile(destination, contents, 0o600); err != nil {
 				return err
 			}

--- a/third_party/open-policy-agent/gatekeeper/helmify/replacements.go
+++ b/third_party/open-policy-agent/gatekeeper/helmify/replacements.go
@@ -1,5 +1,6 @@
 package main
 
+//nolint:gosec // G101: This map contains Helm placeholder names, not credential values.
 var replacements = map[string]string{
 	`HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_CONTAINER_RESOURCES: ""`: `{{- toYaml .Values.deploy.resources | nindent 10 }}`,
 	`HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_NODESELECTOR: ""`:        `{{- toYaml .Values.deploy.nodeSelector | nindent 8 }}`,


### PR DESCRIPTION
**What this PR does / why we need it**:
Trivy deprecated the --vuln-type flag in v0.54.0 in favor of --pkg-types. Since eraser pins trivy 0.67.2, every scan emits:
  WARN '--vuln-type' is deprecated. Use '--pkg-types' instead.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
