### PR TITLE
feat: support Windows containerd named-pipe CRI endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,8 @@ require (
 	sigs.k8s.io/yaml v1.4.0
 )
 
+require github.com/Microsoft/go-winio v0.6.2
+
 require (
 	github.com/BurntSushi/toml v1.4.0 // indirect
 	github.com/alessio/shellescape v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/BurntSushi/toml v1.0.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
+github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/pkg/utils/platform_unix.go
+++ b/pkg/utils/platform_unix.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package utils
+
+import (
+	"context"
+	"net"
+
+	"golang.org/x/sys/unix"
+)
+
+// CRIPath is the in-container path the manager mounts the host CRI socket to.
+const CRIPath = "/run/cri/cri.sock"
+
+const defaultProtocol = unixProtocol
+
+func criDialer(protocol string) (func(ctx context.Context, addr string) (net.Conn, error), error) {
+	if protocol != unixProtocol {
+		return nil, ErrOnlySupportUnixSocket
+	}
+
+	return func(ctx context.Context, addr string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, unixProtocol, addr)
+	}, nil
+}
+
+func mkfifo(path string, mode uint32) error {
+	return unix.Mkfifo(path, mode)
+}

--- a/pkg/utils/platform_unix.go
+++ b/pkg/utils/platform_unix.go
@@ -12,6 +12,9 @@ import (
 // CRIPath is the in-container path the manager mounts the host CRI socket to.
 const CRIPath = "/run/cri/cri.sock"
 
+// unixProtocol is the network protocol of a unix socket.
+const unixProtocol = "unix"
+
 const defaultProtocol = unixProtocol
 
 func criDialer(protocol string) (func(ctx context.Context, addr string) (net.Conn, error), error) {

--- a/pkg/utils/platform_unix_test.go
+++ b/pkg/utils/platform_unix_test.go
@@ -55,14 +55,14 @@ func TestUnixDialerConnects(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	sock := filepath.Join(dir, "s")
 	l, err := net.Listen("unix", sock)
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	defer l.Close()
+	defer func() { _ = l.Close() }()
 	go func() {
 		if c, err := l.Accept(); err == nil {
 			_ = c.Close()

--- a/pkg/utils/platform_unix_test.go
+++ b/pkg/utils/platform_unix_test.go
@@ -1,0 +1,46 @@
+//go:build !windows
+
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestGetAddressAndDialer(t *testing.T) {
+	testCases := []struct {
+		endpoint string
+		addr     string
+		err      error
+	}{
+		{
+			endpoint: fmt.Sprintf("unix://%s", testUnixPath),
+			addr:     testUnixPath,
+			err:      nil,
+		},
+		{
+			endpoint: "localhost:8080",
+			addr:     "",
+			err:      ErrProtocolNotSupported,
+		},
+		{
+			endpoint: "tcp://localhost:8080",
+			addr:     "",
+			err:      ErrOnlySupportUnixSocket,
+		},
+	}
+
+	for _, tc := range testCases {
+		a, _, e := getAddressAndDialer(tc.endpoint)
+		if a != tc.addr || !errors.Is(e, tc.err) {
+			t.Errorf("getAddressAndDialer(%q) = (%q, %v), want (%q, %v)", tc.endpoint, a, e, tc.addr, tc.err)
+		}
+	}
+}
+
+func TestDefaultCRIPathIsUnixSocket(t *testing.T) {
+	if CRIPath != "/run/cri/cri.sock" {
+		t.Errorf("CRIPath = %q, want /run/cri/cri.sock", CRIPath)
+	}
+}

--- a/pkg/utils/platform_unix_test.go
+++ b/pkg/utils/platform_unix_test.go
@@ -3,8 +3,12 @@
 package utils
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"net"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -42,5 +46,54 @@ func TestGetAddressAndDialer(t *testing.T) {
 func TestDefaultCRIPathIsUnixSocket(t *testing.T) {
 	if CRIPath != "/run/cri/cri.sock" {
 		t.Errorf("CRIPath = %q, want /run/cri/cri.sock", CRIPath)
+	}
+}
+
+func TestUnixDialerConnects(t *testing.T) {
+	// short base dir: sun_path is limited to ~108 bytes
+	dir, err := os.MkdirTemp("", "d")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	sock := filepath.Join(dir, "s")
+	l, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer l.Close()
+	go func() {
+		if c, err := l.Accept(); err == nil {
+			_ = c.Close()
+		}
+	}()
+
+	addr, dialer, err := getAddressAndDialer("unix://" + sock)
+	if err != nil {
+		t.Fatalf("getAddressAndDialer: %v", err)
+	}
+
+	conn, err := dialer(context.Background(), addr)
+	if err != nil {
+		t.Fatalf("dial %q: %v", addr, err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Errorf("close: %v", err)
+	}
+}
+
+func TestMkfifoCreatesNamedPipe(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fifo")
+	if err := mkfifo(path, PipeMode); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if fi.Mode()&os.ModeNamedPipe == 0 {
+		t.Errorf("mode = %v, want a named pipe", fi.Mode())
 	}
 }

--- a/pkg/utils/platform_windows.go
+++ b/pkg/utils/platform_windows.go
@@ -23,9 +23,7 @@ func criDialer(protocol string) (func(ctx context.Context, addr string) (net.Con
 		return nil, ErrProtocolNotSupported
 	}
 
-	return func(ctx context.Context, addr string) (net.Conn, error) {
-		return winio.DialPipeContext(ctx, addr)
-	}, nil
+	return winio.DialPipeContext, nil
 }
 
 func mkfifo(path string, mode uint32) error {

--- a/pkg/utils/platform_windows.go
+++ b/pkg/utils/platform_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package utils
+
+import (
+	"context"
+	"errors"
+	"net"
+
+	"github.com/Microsoft/go-winio"
+)
+
+// CRIPath is containerd's named pipe. Unlike Linux there is no socket to mount;
+// a HostProcess pod reaches the pipe directly.
+const CRIPath = `npipe://./pipe/containerd-containerd`
+
+const defaultProtocol = npipeProtocol
+
+var ErrFifoUnsupported = errors.New("named FIFOs are not supported on windows")
+
+func criDialer(protocol string) (func(ctx context.Context, addr string) (net.Conn, error), error) {
+	if protocol != npipeProtocol {
+		return nil, ErrProtocolNotSupported
+	}
+
+	return func(ctx context.Context, addr string) (net.Conn, error) {
+		return winio.DialPipeContext(ctx, addr)
+	}, nil
+}
+
+func mkfifo(path string, mode uint32) error {
+	return ErrFifoUnsupported
+}

--- a/pkg/utils/platform_windows_test.go
+++ b/pkg/utils/platform_windows_test.go
@@ -3,9 +3,13 @@
 package utils
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"os"
 	"testing"
+
+	"github.com/Microsoft/go-winio"
 )
 
 func TestGetAddressAndDialer(t *testing.T) {
@@ -22,6 +26,12 @@ func TestGetAddressAndDialer(t *testing.T) {
 		{
 			// bare pipe name falls back to the npipe protocol
 			endpoint: "./pipe/containerd-containerd",
+			addr:     `\\.\pipe\containerd-containerd`,
+			err:      nil,
+		},
+		{
+			// kubelet spells it with four slashes: empty host, already-UNC path
+			endpoint: "npipe:////./pipe/containerd-containerd",
 			addr:     `\\.\pipe\containerd-containerd`,
 			err:      nil,
 		},
@@ -48,5 +58,33 @@ func TestGetAddressAndDialer(t *testing.T) {
 func TestMkfifoUnsupported(t *testing.T) {
 	if err := mkfifo("ignored", PipeMode); !errors.Is(err, ErrFifoUnsupported) {
 		t.Errorf("mkfifo on windows = %v, want ErrFifoUnsupported", err)
+	}
+}
+
+func TestNpipeDialerConnects(t *testing.T) {
+	name := fmt.Sprintf("eraser-test-%d", os.Getpid())
+
+	l, err := winio.ListenPipe(`\\.\pipe\`+name, nil)
+	if err != nil {
+		t.Fatalf("listen pipe: %v", err)
+	}
+	defer l.Close()
+	go func() {
+		if c, err := l.Accept(); err == nil {
+			_ = c.Close()
+		}
+	}()
+
+	addr, dialer, err := getAddressAndDialer("npipe://./pipe/" + name)
+	if err != nil {
+		t.Fatalf("getAddressAndDialer: %v", err)
+	}
+
+	conn, err := dialer(context.Background(), addr)
+	if err != nil {
+		t.Fatalf("dial %q: %v", addr, err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Errorf("close: %v", err)
 	}
 }

--- a/pkg/utils/platform_windows_test.go
+++ b/pkg/utils/platform_windows_test.go
@@ -1,0 +1,52 @@
+//go:build windows
+
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestGetAddressAndDialer(t *testing.T) {
+	testCases := []struct {
+		endpoint string
+		addr     string
+		err      error
+	}{
+		{
+			endpoint: CRIPath,
+			addr:     `\\.\pipe\containerd-containerd`,
+			err:      nil,
+		},
+		{
+			// bare pipe name falls back to the npipe protocol
+			endpoint: "./pipe/containerd-containerd",
+			addr:     `\\.\pipe\containerd-containerd`,
+			err:      nil,
+		},
+		{
+			endpoint: fmt.Sprintf("unix://%s", testUnixPath),
+			addr:     "",
+			err:      ErrProtocolNotSupported,
+		},
+		{
+			endpoint: "tcp://localhost:8080",
+			addr:     "",
+			err:      ErrProtocolNotSupported,
+		},
+	}
+
+	for _, tc := range testCases {
+		a, _, e := getAddressAndDialer(tc.endpoint)
+		if a != tc.addr || !errors.Is(e, tc.err) {
+			t.Errorf("getAddressAndDialer(%q) = (%q, %v), want (%q, %v)", tc.endpoint, a, e, tc.addr, tc.err)
+		}
+	}
+}
+
+func TestMkfifoUnsupported(t *testing.T) {
+	if err := mkfifo("ignored", PipeMode); !errors.Is(err, ErrFifoUnsupported) {
+		t.Errorf("mkfifo on windows = %v, want ErrFifoUnsupported", err)
+	}
+}

--- a/pkg/utils/platform_windows_test.go
+++ b/pkg/utils/platform_windows_test.go
@@ -68,7 +68,7 @@ func TestNpipeDialerConnects(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listen pipe: %v", err)
 	}
-	defer l.Close()
+	defer func() { _ = l.Close() }()
 	go func() {
 		if c, err := l.Accept(); err == nil {
 			_ = c.Close()

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -20,8 +20,6 @@ import (
 )
 
 const (
-	// unixProtocol is the network protocol of unix socket.
-	unixProtocol = "unix"
 	// npipeProtocol is the network protocol of a Windows named pipe.
 	npipeProtocol            = "npipe"
 	PipeMode                 = 0o644

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	v1 "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -22,15 +21,15 @@ import (
 
 const (
 	// unixProtocol is the network protocol of unix socket.
-	unixProtocol             = "unix"
+	unixProtocol = "unix"
+	// npipeProtocol is the network protocol of a Windows named pipe.
+	npipeProtocol            = "npipe"
 	PipeMode                 = 0o644
 	ScanErasePath            = "/run/eraser.sh/shared-data/scanErase"
 	CollectScanPath          = "/run/eraser.sh/shared-data/collectScan"
 	EraseCompleteCollectPath = "/run/eraser.sh/shared-data/eraseCompleteCollect"
 	EraseCompleteMessage     = "complete"
 	EraseCompleteScanPath    = "/run/eraser.sh/shared-data/eraseCompleteScan"
-
-	CRIPath = "/run/cri/cri.sock"
 
 	EnvEraserRuntimeName = "ERASER_RUNTIME_NAME"
 )
@@ -63,19 +62,17 @@ func GetConn(ctx context.Context, socketPath string) (conn *grpc.ClientConn, err
 }
 
 func getAddressAndDialer(endpoint string) (string, func(ctx context.Context, addr string) (net.Conn, error), error) {
-	protocol, addr, err := ParseEndpointWithFallbackProtocol(endpoint, unixProtocol)
+	protocol, addr, err := ParseEndpointWithFallbackProtocol(endpoint, defaultProtocol)
 	if err != nil {
 		return "", nil, err
 	}
-	if protocol != unixProtocol {
-		return "", nil, ErrOnlySupportUnixSocket
+
+	dialer, err := criDialer(protocol)
+	if err != nil {
+		return "", nil, err
 	}
 
-	return addr, dial, nil
-}
-
-func dial(ctx context.Context, addr string) (net.Conn, error) {
-	return (&net.Dialer{}).DialContext(ctx, unixProtocol, addr)
+	return addr, dialer, nil
 }
 
 func ParseEndpointWithFallbackProtocol(endpoint string, fallbackProtocol string) (protocol string, addr string, err error) {
@@ -100,6 +97,10 @@ func ParseEndpoint(endpoint string) (string, string, error) {
 		return "tcp", u.Host, nil
 	case "unix":
 		return "unix", u.Path, nil
+	case npipeProtocol:
+		// url.Parse splits `npipe://./pipe/foo` into Host "." and Path "/pipe/foo";
+		// both halves are needed to rebuild the `\\.\pipe\foo` name.
+		return npipeProtocol, `\\` + u.Host + strings.ReplaceAll(u.Path, "/", `\`), nil
 	case "":
 		return "", "", fmt.Errorf("using %q as %w", endpoint, ErrEndpointDeprecated)
 	default:
@@ -373,7 +374,7 @@ func WriteScanErasePipe(vulnerableImages []unversioned.Image) error {
 		return err
 	}
 
-	if err = unix.Mkfifo(ScanErasePath, PipeMode); err != nil {
+	if err = mkfifo(ScanErasePath, PipeMode); err != nil {
 		return err
 	}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -98,9 +98,14 @@ func ParseEndpoint(endpoint string) (string, string, error) {
 	case "unix":
 		return "unix", u.Path, nil
 	case npipeProtocol:
-		// url.Parse splits `npipe://./pipe/foo` into Host "." and Path "/pipe/foo";
-		// both halves are needed to rebuild the `\\.\pipe\foo` name.
-		return npipeProtocol, `\\` + u.Host + strings.ReplaceAll(u.Path, "/", `\`), nil
+		// Two spellings are in the wild. `npipe://./pipe/foo` splits into Host "."
+		// and Path "/pipe/foo", so both halves are needed. The kubelet form
+		// `npipe:////./pipe/foo` has an empty host and an already-UNC path.
+		addr := strings.ReplaceAll(u.Path, "/", `\`)
+		if u.Host != "" {
+			addr = `\\` + u.Host + addr
+		}
+		return npipeProtocol, addr, nil
 	case "":
 		return "", "", fmt.Errorf("using %q as %w", endpoint, ErrEndpointDeprecated)
 	default:

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -7,6 +7,10 @@ import (
 	"testing"
 )
 
+// testUnixPath is used instead of CRIPath so these cases stay valid on Windows,
+// where CRIPath is a named pipe.
+const testUnixPath = "/run/cri/cri.sock"
+
 func TestParseEndpointWithFallBackProtocol(t *testing.T) {
 	testCases := []struct {
 		endpoint         string
@@ -16,10 +20,21 @@ func TestParseEndpointWithFallBackProtocol(t *testing.T) {
 		errCheck         func(t *testing.T, err error)
 	}{
 		{
-			endpoint:         fmt.Sprintf("unix://%s", CRIPath),
+			endpoint:         fmt.Sprintf("unix://%s", testUnixPath),
 			fallbackProtocol: "unix",
 			protocol:         "unix",
-			addr:             CRIPath,
+			addr:             testUnixPath,
+			errCheck: func(t *testing.T, err error) {
+				if err != nil {
+					t.Error(err)
+				}
+			},
+		},
+		{
+			endpoint:         "./pipe/containerd-containerd",
+			fallbackProtocol: "npipe",
+			protocol:         "npipe",
+			addr:             `\\.\pipe\containerd-containerd`,
 			errCheck: func(t *testing.T, err error) {
 				if err != nil {
 					t.Error(err)
@@ -81,9 +96,19 @@ func TestParseEndpoint(t *testing.T) {
 		errCheck func(t *testing.T, err error)
 	}{
 		{
-			endpoint: fmt.Sprintf("unix://%s", CRIPath),
+			endpoint: fmt.Sprintf("unix://%s", testUnixPath),
 			protocol: "unix",
-			addr:     CRIPath,
+			addr:     testUnixPath,
+			errCheck: func(t *testing.T, err error) {
+				if err != nil {
+					t.Error(err)
+				}
+			},
+		},
+		{
+			endpoint: "npipe://./pipe/containerd-containerd",
+			protocol: "npipe",
+			addr:     `\\.\pipe\containerd-containerd`,
 			errCheck: func(t *testing.T, err error) {
 				if err != nil {
 					t.Error(err)
@@ -130,36 +155,5 @@ func TestParseEndpoint(t *testing.T) {
 		}
 
 		tc.errCheck(t, e)
-	}
-}
-
-func TestGetAddressAndDialer(t *testing.T) {
-	testCases := []struct {
-		endpoint string
-		addr     string
-		err      error
-	}{
-		{
-			endpoint: fmt.Sprintf("unix://%s", CRIPath),
-			addr:     CRIPath,
-			err:      nil,
-		},
-		{
-			endpoint: "localhost:8080",
-			addr:     "",
-			err:      ErrProtocolNotSupported,
-		},
-		{
-			endpoint: "tcp://localhost:8080",
-			addr:     "",
-			err:      ErrOnlySupportUnixSocket,
-		},
-	}
-
-	for _, tc := range testCases {
-		a, _, e := getAddressAndDialer(tc.endpoint)
-		if a != tc.addr || !errors.Is(e, tc.err) {
-			t.Errorf("Test fails")
-		}
 	}
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -42,6 +42,18 @@ func TestParseEndpointWithFallBackProtocol(t *testing.T) {
 			},
 		},
 		{
+			// the form kubelet accepts for --container-runtime-endpoint
+			endpoint:         "npipe:////./pipe/containerd-containerd",
+			fallbackProtocol: "npipe",
+			protocol:         "npipe",
+			addr:             `\\.\pipe\containerd-containerd`,
+			errCheck: func(t *testing.T, err error) {
+				if err != nil {
+					t.Error(err)
+				}
+			},
+		},
+		{
 			endpoint:         "192.168.123.132",
 			fallbackProtocol: "unix",
 			protocol:         "unix",
@@ -107,6 +119,17 @@ func TestParseEndpoint(t *testing.T) {
 		},
 		{
 			endpoint: "npipe://./pipe/containerd-containerd",
+			protocol: "npipe",
+			addr:     `\\.\pipe\containerd-containerd`,
+			errCheck: func(t *testing.T, err error) {
+				if err != nil {
+					t.Error(err)
+				}
+			},
+		},
+		{
+			// kubelet spells it with four slashes: empty host, already-UNC path
+			endpoint: "npipe:////./pipe/containerd-containerd",
 			protocol: "npipe",
 			addr:     `\\.\pipe\containerd-containerd`,
 			errCheck: func(t *testing.T, err error) {


### PR DESCRIPTION
## What

Adds support for Windows containerd's named-pipe CRI endpoint (`npipe://./pipe/containerd-containerd`) in `pkg/utils`, and makes that package build for `GOOS=windows`.

Picks up part of #169.

## Why

`pkg/utils` assumed a Unix socket in three separate places:

- `ParseEndpoint` accepted only `tcp` and `unix`
- the dialer was hardcoded to `net.Dial` on the `"unix"` network
- `CRIPath` was a fixed Linux path

It also imported `golang.org/x/sys/unix` unconditionally for `Mkfifo`, so the package did not compile for `GOOS=windows` at all — which in turn blocked `pkg/cri` and `pkg/remover`.

## How

OS-specific pieces move behind build-tagged files rather than being conditionally branched inline:

| | `platform_unix.go` | `platform_windows.go` |
|---|---|---|
| `CRIPath` | `/run/cri/cri.sock` | `npipe://./pipe/containerd-containerd` |
| `defaultProtocol` | `unix` | `npipe` |
| `criDialer` | `net.Dialer` | `winio.DialPipeContext` |
| `mkfifo` | `unix.Mkfifo` | returns `ErrFifoUnsupported` |

`ParseEndpoint` learns the `npipe` scheme. Note that `url.Parse("npipe://./pipe/containerd-containerd")` splits the name across `URL.Host` (`.`) and `URL.Path` (`/pipe/containerd-containerd`), so both halves are needed to rebuild `\\.\pipe\containerd-containerd`; using `Path` alone silently yields an invalid pipe name.

This adds one dependency, `github.com/Microsoft/go-winio`, used only in the Windows build. `winio.DialPipeContext` returns a `net.Conn` directly; the `golang.org/x/sys/windows` alternative would require hand-rolling `net.Conn` over a file handle.

## Not a breaking change

- **Linux behaviour is byte-for-byte unchanged** — same `CRIPath`, same default protocol, same dialer, same `ErrOnlySupportUnixSocket` for non-unix schemes.
- **Purely additive at the API level.** `npipe` is a newly *accepted* input; every previously valid endpoint stays valid and resolves identically.
- **No exported symbol removed or changed.** `CRIPath` moves from `utils.go` to a build-tagged file but keeps its name, type and Linux value.
- **No CRD, config schema or generated code touched.** No `zz_generated.*` regeneration.
- **Nothing is scheduled onto Windows nodes by this PR.** The manager still emits Linux-shaped ImageJob pod specs, and `pkg/collector` / `pkg/scanners/template` still don't build for Windows. This is a prerequisite, not an enablement.

## Testing

**Unit** — `ParseEndpoint` / `ParseEndpointWithFallbackProtocol` gain `npipe` cases. `TestGetAddressAndDialer` was platform-specific in practice, so it's split into `platform_unix_test.go` and `platform_windows_test.go`. The shared tests no longer key off `CRIPath`, so they're valid on both OSes.

**On a real node** — verified on an AKS Windows Server 2022 node, containerd `1.7.20+azure`, from a HostProcess pod:

```
endpoint       : npipe://./pipe/containerd-containerd
dial           : OK (5ms)
ListImages     : OK 38 images, 4.96 GB
ListContainers : OK 16 containers
DeleteImage    : OK "mcr.microsoft.com/windows/servercore:ltsc2022" in 1m13.992s
verify         : 38 images before, 37 after
```

That path is `cri.NewRemoverClient` → `utils.GetConn` → gRPC over the pipe, i.e. this repo's own client, not `crictl`.

**CI** — cross-compile + `go vet` for `windows/amd64` on `pkg/utils`, `pkg/cri`, `pkg/remover`; native `go test` on `windows-latest`; and a full Linux `go build ./...` + `go test` regression run. All green.

## Follow-ups, not in this PR

- `pkg/collector` and `pkg/scanners/template` still call `unix.Mkfifo`. The collector/scanner/remover handoff uses Unix FIFOs and relies on blocking `open()` for rendezvous, so it needs its own design discussion — happy to open an issue.
- OS-aware ImageJob pod specs (HostProcess `securityContext`, no CRI hostPath mount).
- Worth flagging separately: `DeleteImage` took ~74s for a single 2.1 GB Windows image, while `pkg/remover` wraps `ListImages` + `ListContainers` + *every* `DeleteImage` in one 5-minute context. That budget is exceeded by roughly four large images.

## Two notes for reviewers

Two things I'd particularly like your opinion on:

1. Whether you'd prefer the per-GOOS split as done here, or explicit per-OS configuration in `EraserConfig`.
2. `RuntimeSpec.UnmarshalJSON` in `api/unversioned` and `api/v1alpha3` still rejects the `npipe` scheme, so a named pipe can't be set via `manager.runtime.address` yet. I left that out deliberately — accepting it there without the OS-aware pod spec change would let the manager build a hostPath mount from a pipe name. Happy to add it in a follow-up once the pod-spec side lands, or here if you'd rather.


## Standalone E2E test results

Upstream has no Windows CI, so this change was validated on a personal fork against a real AKS Windows node. Everything below is reproducible with the linked script.

<details>
<summary><b>Harness</b> — where the tooling lives</summary>

| | |
|---|---|
| Manual E2E runner | [`hack/windows-e2e.ps1`](https://github.com/charleswool/eraser/blob/main/hack/windows-e2e.ps1) |
| Build + unit workflow | [`.github/workflows/windows-ci.yaml`](https://github.com/charleswool/eraser/blob/main/.github/workflows/windows-ci.yaml) |
| CRI checker | [`hack/winspike`](https://github.com/charleswool/eraser/blob/main/hack/winspike/main.go) |

The runner scales a long-lived AKS Windows node pool `0 -> 1`, cross-compiles the checker for `windows/amd64`, copies it onto the node, exercises the CRI API over the named pipe from a HostProcess pod, then scales back to `0` in a `finally` block.

The checker is a thin wrapper over **this repo's own `pkg/cri`** — `cri.NewRemoverClient` -> `utils.GetConn` -> gRPC over the pipe. It is not `crictl`.

The workflow covers, on every push:

- cross-compile + `go vet` of `pkg/utils`, `pkg/cri` and `pkg/remover` for `windows/amd64`
- `go test` natively on `windows-latest`
- a full Linux `go build ./...` + `go test` regression job

</details>

<details>
<summary><b>Environment</b></summary>

| | |
|---|---|
| Cluster | AKS 1.35 |
| Node | Windows Server 2022 Datacenter, build 10.0.20348 |
| Runtime | containerd 1.7.20+azure |
| Pod | HostProcess, base `mcr.microsoft.com/windows/nanoserver:ltsc2022` |
| Identity | `runAsUserName: NT AUTHORITY\SYSTEM` |
| Endpoint | `npipe://./pipe/containerd-containerd` |

</details>

<details>
<summary><b>Live results</b> — commit <code>5dac6a93</code>, the head of this PR</summary>

```text
=== code under test ===
5dac6a93 (HEAD -> feat/windows-npipe-cri-transport) feat: support Windows containerd named-pipe CRI endpoints

=== wait for a ready windows node ===
  node: aksnpwin000001

=== build checker for windows/amd64 ===
  size = 21.8 MB

=== start HostProcess pod ===
pod/winspike created
pod/winspike condition met

=== list and delete the largest unused image over npipe ===
endpoint       : npipe://./pipe/containerd-containerd
default CRIPath: npipe://./pipe/containerd-containerd
dial           : OK (3ms)
ListImages     : OK 39 images, 6.90 GB
ListContainers : OK 13 containers
unused images  : 30
  mcr.microsoft.com/windows/servercore:10.0.20348.5386                     1.96 GB
  mcr.microsoft.com/windows/servercore:10.0.20348.5256                     1.93 GB
  mcr.microsoft.com/oss/kubernetes/pause:3.9-hotfix-20230808               0.29 GB
  mcr.microsoft.com/containernetworking/azure-cni:v1.5.50                  0.19 GB
  mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.17.0            0.14 GB
  ... and 25 more
DeleteImage    : OK "mcr.microsoft.com/windows/servercore:10.0.20348.5386" in 53.546s
verify         : OK 39 images before, 38 after
timing         : 54s to delete one image

=== least-privilege regression (LocalService must be denied) ===
pod/winspike-lowpriv created
  expected: LocalService denied on the containerd pipe

=== cleanup ===
  windows pool scaled back to 0

RESULT: PASS
```

</details>

<details>
<summary><b>Two observations from the run</b> — not addressed in this PR</summary>

**`NT AUTHORITY\SYSTEM` appears to be required.** Both `LocalService` and `NetworkService` are refused by the containerd pipe ACL:

```text
transport: Error while dialing: open //./pipe/containerd-containerd: Access is denied.
```

The runner asserts this so a future ACL change is noticed rather than silently widening what a Windows worker pod needs.

**Image deletion is slow, and the cost tracks unique layer bytes rather than reported size.** Measured on the same node:

| Image | Reported size | Delete time |
|---|---|---|
| `servercore/iis:windowsservercore-ltsc2022` | 2.03 GB | 15s |
| `servercore:10.0.20348.5386` | 1.96 GB | 54s |
| `servercore:10.0.20348.5256` | 1.93 GB | 74s |

The iis image is layered on servercore, so most of its content was still referenced. Since the cost is not predictable from the image list, a safe batch size cannot be computed up front — which matters because `pkg/remover` wraps `ListImages`, `ListContainers` and *every* `DeleteImage` in a single 5-minute context. That is roughly four large Windows images per run, against 30 unused images on a freshly created node.

Out of scope here; flagging it as a follow-up rather than folding an unrelated fix into a transport PR.

</details>
