### PR TITLE
fix(trivy): fail fast when trivy binary is not found

### DIFF
--- a/pkg/scanners/trivy/trivy.go
+++ b/pkg/scanners/trivy/trivy.go
@@ -67,6 +67,15 @@ func main() {
 	log.Info("trivy version", "trivy version", trivyVersion)
 	log.Info("config", "config", *config)
 
+	if _, err := os.Stat(trivyCommandName); err != nil {
+		if os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "trivy binary not found at %s\n", trivyCommandName)
+			os.Exit(generalErr)
+		}
+		log.Error(err, "unable to stat trivy binary")
+		os.Exit(generalErr)
+	}
+
 	userConfig := *DefaultConfig()
 	if *config != "" {
 		var err error

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -51,9 +51,14 @@ func GetConn(ctx context.Context, socketPath string) (conn *grpc.ClientConn, err
 		return nil, err
 	}
 
+	// Use a timeout context so we fail fast instead of hanging indefinitely
+	// when the CRI socket is inaccessible (e.g. permission denied).
+	connCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	//nolint:staticcheck // SA1019: grpc.DialContext is deprecated but maintains required blocking behavior
 	return grpc.DialContext(
-		ctx,
+		connCtx,
 		addr,
 		//nolint:staticcheck // SA1019: grpc.WithBlock is deprecated but ensures synchronous CRI connection
 		grpc.WithBlock(),


### PR DESCRIPTION
Fixes #1149

When the trivy binary at /trivy cannot be found, the scanner previously
logged an error and continued processing, silently swallowing the failure.
This made it impossible to distinguish between a missing binary and a
successful scan.

Add a pre-flight os.Stat check in main() to exit immediately with a
clear error message when the trivy binary is missing.

```release-notes
[BUGFIX] trivy: fail fast when trivy binary is not found at /trivy
```