### PR TITLE
feat: run the worker handoff over Unix sockets on Windows

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -86,11 +86,15 @@ func main() {
 		log.Error(err, "failed to create pipe", "pipeFile", util.EraseCompleteCollectPath)
 		os.Exit(1)
 	}
-	defer completion.Close()
 
 	data, err := completion.Await()
 	if err != nil {
 		log.Error(err, "failed to read pipe", "pipeFile", util.EraseCompleteCollectPath)
+		os.Exit(1)
+	}
+
+	if err := completion.Close(); err != nil {
+		log.Error(err, "failed to close pipe", "pipeFile", util.EraseCompleteCollectPath)
 		os.Exit(1)
 	}
 

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -76,14 +76,17 @@ func main() {
 		path = util.ScanErasePath
 	}
 
-	if err := util.WriteImagesPipe(path, finalImages); err != nil {
-		log.Error(err, "failed to send images", "pipeFile", path)
-		os.Exit(1)
-	}
-
+	// Published before the payload, not after: the peer can finish and signal
+	// back the moment it has read the list, so an endpoint created afterwards
+	// can be missed entirely. The scanner already publishes in this order.
 	completion, err := util.CreateCompletionPipe(util.EraseCompleteCollectPath)
 	if err != nil {
 		log.Error(err, "failed to create pipe", "pipeFile", util.EraseCompleteCollectPath)
+		os.Exit(1)
+	}
+
+	if err := util.WriteImagesPipe(path, finalImages); err != nil {
+		log.Error(err, "failed to send images", "pipeFile", path)
 		os.Exit(1)
 	}
 

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -12,7 +10,6 @@ import (
 
 	"github.com/eraser-dev/eraser/pkg/cri"
 	"github.com/eraser-dev/eraser/pkg/logger"
-	"golang.org/x/sys/unix"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	util "github.com/eraser-dev/eraser/pkg/utils"
@@ -73,58 +70,27 @@ func main() {
 	}
 	log.Info("images collected", "finalImages:", finalImages)
 
-	data, err := json.Marshal(finalImages)
-	if err != nil {
-		log.Error(err, "failed to encode finalImages")
-		os.Exit(1)
-	}
-
 	path := util.CollectScanPath
 
 	if *scanDisabled {
 		path = util.ScanErasePath
 	}
 
-	if err := unix.Mkfifo(path, util.PipeMode); err != nil {
-		log.Error(err, "failed to create pipe", "pipeFile", path)
+	if err := util.WriteImagesPipe(path, finalImages); err != nil {
+		log.Error(err, "failed to send images", "pipeFile", path)
 		os.Exit(1)
 	}
 
-	//nolint:gosec // G304: Opening pipe file is intended functionality
-	file, err := os.OpenFile(path, os.O_WRONLY, 0)
+	completion, err := util.CreateCompletionPipe(util.EraseCompleteCollectPath)
 	if err != nil {
-		log.Error(err, "failed to open pipe", "pipeFile", path)
-		os.Exit(1)
-	}
-
-	if _, err := file.Write(data); err != nil {
-		log.Error(err, "failed to write to pipe", "pipeFile", path)
-		os.Exit(1)
-	}
-
-	if err := file.Close(); err != nil {
-		log.Error(err, "failed to close pipe", "pipeFile", path)
-		os.Exit(1)
-	}
-	if err := unix.Mkfifo(util.EraseCompleteCollectPath, util.PipeMode); err != nil {
 		log.Error(err, "failed to create pipe", "pipeFile", util.EraseCompleteCollectPath)
 		os.Exit(1)
 	}
+	defer completion.Close()
 
-	file, err = os.OpenFile(util.EraseCompleteCollectPath, os.O_RDONLY, 0)
-	if err != nil {
-		log.Error(err, "failed to open pipe", "pipeFile", util.EraseCompleteCollectPath)
-		os.Exit(1)
-	}
-
-	data, err = io.ReadAll(file)
+	data, err := completion.Await()
 	if err != nil {
 		log.Error(err, "failed to read pipe", "pipeFile", util.EraseCompleteCollectPath)
-		os.Exit(1)
-	}
-
-	if err := file.Close(); err != nil {
-		log.Error(err, "failed to close pipe", "pipeFile", util.EraseCompleteCollectPath)
 		os.Exit(1)
 	}
 

--- a/pkg/remover/remover.go
+++ b/pkg/remover/remover.go
@@ -2,11 +2,8 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
-	"io/fs"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -21,7 +18,6 @@ import (
 	"github.com/eraser-dev/eraser/pkg/logger"
 	"github.com/eraser-dev/eraser/pkg/metrics"
 
-	"github.com/eraser-dev/eraser/api/unversioned"
 	util "github.com/eraser-dev/eraser/pkg/utils"
 )
 
@@ -78,36 +74,9 @@ func main() {
 	}
 
 	if *imageListPtr == "" {
-		var f *os.File
-		for {
-			var err error
-
-			f, err = os.OpenFile(util.ScanErasePath, os.O_RDONLY, 0)
-			if err == nil {
-				break
-			}
-			if !os.IsNotExist(err) {
-				log.Error(err, "error opening scanErase pipe")
-				os.Exit(generalErr)
-			}
-			time.Sleep(1 * time.Second)
-			continue
-		}
-
-		// json data is list of []unversioned.Image
-		data, err := io.ReadAll(f)
+		nonCompliantImages, err := util.ReadImagesPipe(context.Background(), util.ScanErasePath)
 		if err != nil {
 			log.Error(err, "error reading non-compliant images")
-			os.Exit(generalErr)
-		}
-		if err := f.Close(); err != nil {
-			log.Error(err, "error closing non-compliant images file")
-			os.Exit(generalErr)
-		}
-
-		nonCompliantImages := []unversioned.Image{}
-		if err = json.Unmarshal(data, &nonCompliantImages); err != nil {
-			log.Error(err, "error in unmarshal non-compliant images")
 			os.Exit(generalErr)
 		}
 
@@ -158,39 +127,18 @@ func main() {
 	}
 
 	if *imageListPtr == "" {
-		file, err := os.OpenFile(util.EraseCompleteCollectPath, os.O_WRONLY, 0)
-		if err != nil {
-			log.Error(err, "unable to open pipe", "pipeFile", util.EraseCompleteCollectPath)
+		if err := util.WriteCompletionPipe(util.EraseCompleteCollectPath); err != nil {
+			log.Error(err, "unable to signal completion", "pipeFile", util.EraseCompleteCollectPath)
 			os.Exit(generalErr)
 		}
 
-		if _, err := file.WriteString(util.EraseCompleteMessage); err != nil {
-			log.Error(err, "unable to write to pipe", "pipeFile", util.EraseCompleteCollectPath)
-			os.Exit(generalErr)
-		}
-
-		if err := file.Close(); err != nil {
-			log.Error(err, "unable to close pipe", "pipeFile", util.EraseCompleteCollectPath)
-			os.Exit(generalErr)
-		}
-
-		file, err = os.OpenFile(util.EraseCompleteScanPath, os.O_WRONLY, fs.ModeNamedPipe)
+		err := util.WriteCompletionPipe(util.EraseCompleteScanPath)
 		// if the scanner is disabled
 		if os.IsNotExist(err) {
 			return
 		}
 		if err != nil {
-			log.Error(err, "unable to open pipe", "pipeFile", util.EraseCompleteCollectPath)
-			os.Exit(generalErr)
-		}
-
-		if _, err := file.WriteString(util.EraseCompleteMessage); err != nil {
-			log.Error(err, "unable to write to pipe", "pipeFile", util.EraseCompleteCollectPath)
-			os.Exit(generalErr)
-		}
-
-		if err := file.Close(); err != nil {
-			log.Error(err, "unable to close pipe", "pipeFile", util.EraseCompleteScanPath)
+			log.Error(err, "unable to signal completion", "pipeFile", util.EraseCompleteScanPath)
 			os.Exit(generalErr)
 		}
 	}

--- a/pkg/scanners/template/scanner_template.go
+++ b/pkg/scanners/template/scanner_template.go
@@ -111,7 +111,7 @@ func (cfg *config) SendImages(nonCompliantImages, failedImages []unversioned.Ima
 }
 
 func (cfg *config) Finish() error {
-	defer cfg.completion.Close()
+	defer func() { _ = cfg.completion.Close() }()
 
 	data, err := cfg.completion.Await()
 	if err != nil {

--- a/pkg/scanners/template/scanner_template.go
+++ b/pkg/scanners/template/scanner_template.go
@@ -2,14 +2,12 @@ package template
 
 import (
 	"context"
-	"io"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/eraser-dev/eraser/api/unversioned"
 	"github.com/go-logr/logr"
-	"golang.org/x/sys/unix"
 
 	"github.com/eraser-dev/eraser/pkg/metrics"
 	util "github.com/eraser-dev/eraser/pkg/utils"
@@ -35,6 +33,10 @@ type config struct {
 	deleteScanFailedImages bool
 	deleteEOLImages        bool
 	reportMetrics          bool
+
+	// held from ReceiveImages until Finish: the endpoint must stay published so
+	// the remover can tell a scanner is present
+	completion *util.CompletionPipe
 }
 
 type ConfigFunc func(*config)
@@ -59,7 +61,9 @@ func NewImageProvider(funcs ...ConfigFunc) ImageProvider {
 func (cfg *config) ReceiveImages() ([]unversioned.Image, error) {
 	var err error
 
-	if err := unix.Mkfifo(util.EraseCompleteScanPath, util.PipeMode); err != nil {
+	// published up front so the remover can tell a scanner is present
+	cfg.completion, err = util.CreateCompletionPipe(util.EraseCompleteScanPath)
+	if err != nil {
 		cfg.log.Error(err, "failed to create pipe", "pipeName", util.EraseCompleteScanPath)
 		return nil, err
 	}
@@ -107,20 +111,11 @@ func (cfg *config) SendImages(nonCompliantImages, failedImages []unversioned.Ima
 }
 
 func (cfg *config) Finish() error {
-	file, err := os.OpenFile(util.EraseCompleteScanPath, os.O_RDONLY, 0)
-	if err != nil {
-		cfg.log.Error(err, "failed to open pipe", "pipeName", util.EraseCompleteScanPath)
-		return err
-	}
+	defer cfg.completion.Close()
 
-	data, err := io.ReadAll(file)
+	data, err := cfg.completion.Await()
 	if err != nil {
 		cfg.log.Error(err, "failed to read pipe", "pipeName", util.EraseCompleteScanPath)
-		return err
-	}
-
-	if err := file.Close(); err != nil {
-		cfg.log.Error(err, "failed to close pipe", "pipeName", util.EraseCompleteScanPath)
 		return err
 	}
 

--- a/pkg/utils/handoff.go
+++ b/pkg/utils/handoff.go
@@ -1,0 +1,150 @@
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"time"
+
+	"github.com/eraser-dev/eraser/api/unversioned"
+)
+
+// The collector, scanner and remover hand images off to each other through
+// endpoints in a shared volume. Each operation below was previously written out
+// inline in the three worker binaries; they are gathered here so the transport
+// can be swapped per platform without touching the callers.
+//
+// Three properties are load-bearing and must survive any reimplementation.
+// Connecting blocks until the peer is on the other end, which is what makes
+// arbitrary container start order safe. The reader sees EOF when the writer
+// finishes, which is what frames a message. And the absence of an endpoint is
+// itself meaningful: the remover infers that the scanner is disabled from
+// ENOENT on the scanner's completion endpoint.
+
+// CompletionPipe is an endpoint a peer can observe before anything is read from
+// it. The scanner creates one early precisely so the remover can tell a scanner
+// is present.
+type CompletionPipe struct {
+	path string
+}
+
+// CreateCompletionPipe publishes the endpoint without waiting for a peer.
+func CreateCompletionPipe(path string) (*CompletionPipe, error) {
+	if err := mkfifo(path, PipeMode); err != nil {
+		return nil, err
+	}
+	return &CompletionPipe{path: path}, nil
+}
+
+// Await blocks until a peer signals completion. The payload is returned
+// unvalidated so callers keep their existing handling of unexpected content.
+func (p *CompletionPipe) Await() ([]byte, error) {
+	//nolint:gosec // G304: Opening pipe file is intended functionality
+	file, err := os.OpenFile(p.path, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := file.Close(); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// Close releases the endpoint. It is a no-op where the endpoint is a plain
+// filesystem object.
+func (p *CompletionPipe) Close() error {
+	return nil
+}
+
+// WriteImagesPipe publishes the endpoint and blocks until the reader connects.
+func WriteImagesPipe(path string, images []unversioned.Image) error {
+	data, err := json.Marshal(images)
+	if err != nil {
+		return err
+	}
+
+	if err := mkfifo(path, PipeMode); err != nil {
+		return err
+	}
+
+	//nolint:gosec // G304: Opening pipe file is intended functionality
+	file, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+
+	if _, err := file.Write(data); err != nil {
+		return err
+	}
+
+	return file.Close()
+}
+
+// ReadImagesPipe waits for the endpoint to appear, then reads until the writer
+// finishes. It returns ctx.Err() if the context is cancelled while waiting.
+func ReadImagesPipe(ctx context.Context, path string) ([]unversioned.Image, error) {
+	timer := time.NewTimer(time.Second)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	defer timer.Stop()
+
+	var f *os.File
+	for {
+		var err error
+
+		//nolint:gosec // G304: Opening pipe file is intended functionality
+		f, err = os.OpenFile(path, os.O_RDONLY, 0)
+		if err == nil {
+			break
+		}
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+
+		timer.Reset(time.Second)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-timer.C:
+			continue
+		}
+	}
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+
+	images := []unversioned.Image{}
+	if err := json.Unmarshal(data, &images); err != nil {
+		return nil, err
+	}
+
+	return images, nil
+}
+
+// WriteCompletionPipe signals a peer that this stage is done. The returned error
+// satisfies os.IsNotExist when the peer never published the endpoint, which is
+// how an absent scanner is detected.
+func WriteCompletionPipe(path string) error {
+	//nolint:gosec // G304: Opening pipe file is intended functionality
+	file, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+
+	if _, err := file.WriteString(EraseCompleteMessage); err != nil {
+		return err
+	}
+
+	return file.Close()
+}

--- a/pkg/utils/handoff_test.go
+++ b/pkg/utils/handoff_test.go
@@ -102,7 +102,12 @@ func TestCompletionPipeCloseIsIdempotentlySafe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateCompletionPipe: %v", err)
 	}
+
+	// the scanner defers Close and the collector also closes explicitly
 	if err := pipe.Close(); err != nil {
-		t.Errorf("Close: %v", err)
+		t.Errorf("first Close: %v", err)
+	}
+	if err := pipe.Close(); err != nil {
+		t.Errorf("second Close: %v", err)
 	}
 }

--- a/pkg/utils/handoff_test.go
+++ b/pkg/utils/handoff_test.go
@@ -1,0 +1,108 @@
+package utils
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eraser-dev/eraser/api/unversioned"
+)
+
+// These run against whichever implementation the platform selects: FIFOs on
+// Unix, Unix domain sockets on Windows. Keeping them build-tag free is the point
+// -- the two implementations have to stay behaviorally identical.
+
+// shortTempDir keeps paths well inside the sun_path limit that applies to the
+// socket implementation.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "h")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	return dir
+}
+
+func TestImagesHandoffRoundTrip(t *testing.T) {
+	path := filepath.Join(shortTempDir(t), "images")
+
+	want := []unversioned.Image{
+		{ImageID: "sha256:aaaa", Names: []string{"repo/one:v1"}},
+		{ImageID: "sha256:bbbb", Names: []string{"repo/two:v2"}},
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- WriteImagesPipe(path, want) }()
+
+	got, err := ReadImagesPipe(context.Background(), path)
+	if err != nil {
+		t.Fatalf("ReadImagesPipe: %v", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("WriteImagesPipe: %v", err)
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("got %d images, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].ImageID != want[i].ImageID {
+			t.Errorf("image %d = %q, want %q", i, got[i].ImageID, want[i].ImageID)
+		}
+	}
+}
+
+func TestCompletionHandoffRoundTrip(t *testing.T) {
+	path := filepath.Join(shortTempDir(t), "complete")
+
+	pipe, err := CreateCompletionPipe(path)
+	if err != nil {
+		t.Fatalf("CreateCompletionPipe: %v", err)
+	}
+	defer func() { _ = pipe.Close() }()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- WriteCompletionPipe(path) }()
+
+	data, err := pipe.Await()
+	if err != nil {
+		t.Fatalf("Await: %v", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("WriteCompletionPipe: %v", err)
+	}
+
+	if string(data) != EraseCompleteMessage {
+		t.Errorf("payload = %q, want %q", string(data), EraseCompleteMessage)
+	}
+}
+
+// The remover infers "the scanner is disabled" from this error, so it has to
+// keep satisfying os.IsNotExist on both platforms.
+func TestWriteCompletionPipeAbsentPeerIsNotExist(t *testing.T) {
+	path := filepath.Join(shortTempDir(t), "no-such-peer")
+
+	err := WriteCompletionPipe(path)
+	if err == nil {
+		t.Fatal("expected an error writing to an endpoint nobody published")
+	}
+	if !os.IsNotExist(err) {
+		t.Errorf("os.IsNotExist(%v) = false, want true", err)
+	}
+}
+
+func TestCompletionPipeCloseIsIdempotentlySafe(t *testing.T) {
+	path := filepath.Join(shortTempDir(t), "closed")
+
+	pipe, err := CreateCompletionPipe(path)
+	if err != nil {
+		t.Fatalf("CreateCompletionPipe: %v", err)
+	}
+	if err := pipe.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}

--- a/pkg/utils/handoff_unix.go
+++ b/pkg/utils/handoff_unix.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package utils
 
 import (
@@ -11,9 +13,8 @@ import (
 )
 
 // The collector, scanner and remover hand images off to each other through
-// endpoints in a shared volume. Each operation below was previously written out
-// inline in the three worker binaries; they are gathered here so the transport
-// can be swapped per platform without touching the callers.
+// endpoints in a shared volume. On Unix those endpoints are FIFOs; see
+// handoff_windows.go for the socket-based equivalent.
 //
 // Three properties are load-bearing and must survive any reimplementation.
 // Connecting blocks until the peer is on the other end, which is what makes
@@ -89,7 +90,7 @@ func WriteImagesPipe(path string, images []unversioned.Image) error {
 }
 
 // ReadImagesPipe waits for the endpoint to appear, then reads until the writer
-// finishes. It returns ctx.Err() if the context is cancelled while waiting.
+// finishes. It returns ctx.Err() if the context is canceled while waiting.
 func ReadImagesPipe(ctx context.Context, path string) ([]unversioned.Image, error) {
 	timer := time.NewTimer(time.Second)
 	if !timer.Stop() {

--- a/pkg/utils/handoff_unix.go
+++ b/pkg/utils/handoff_unix.go
@@ -48,19 +48,22 @@ func (p *CompletionPipe) Await() ([]byte, error) {
 	}
 
 	data, err := io.ReadAll(file)
-	if err != nil {
-		return nil, err
+	if closeErr := file.Close(); closeErr != nil && err == nil {
+		err = closeErr
 	}
-
-	if err := file.Close(); err != nil {
+	if err != nil {
 		return nil, err
 	}
 
 	return data, nil
 }
 
-// Close releases the endpoint. It is a no-op where the endpoint is a plain
-// filesystem object.
+// Close releases this process's hold on the endpoint. The FIFO itself is left
+// in place: the remover decides whether a scanner exists by whether the
+// scanner's endpoint is on disk, so unlinking here would make a live scanner
+// look absent. The socket implementation cannot keep the endpoint after Close
+// because the listener owns it, which is the one lifecycle difference between
+// the two.
 func (p *CompletionPipe) Close() error {
 	return nil
 }
@@ -82,11 +85,12 @@ func WriteImagesPipe(path string, images []unversioned.Image) error {
 		return err
 	}
 
-	if _, err := file.Write(data); err != nil {
-		return err
+	_, err = file.Write(data)
+	if closeErr := file.Close(); closeErr != nil && err == nil {
+		err = closeErr
 	}
 
-	return file.Close()
+	return err
 }
 
 // ReadImagesPipe waits for the endpoint to appear, then reads until the writer
@@ -121,6 +125,9 @@ func ReadImagesPipe(ctx context.Context, path string) ([]unversioned.Image, erro
 	}
 
 	data, err := io.ReadAll(f)
+	if closeErr := f.Close(); closeErr != nil && err == nil {
+		err = closeErr
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -143,9 +150,10 @@ func WriteCompletionPipe(path string) error {
 		return err
 	}
 
-	if _, err := file.WriteString(EraseCompleteMessage); err != nil {
-		return err
+	_, err = file.WriteString(EraseCompleteMessage)
+	if closeErr := file.Close(); closeErr != nil && err == nil {
+		err = closeErr
 	}
 
-	return file.Close()
+	return err
 }

--- a/pkg/utils/handoff_windows.go
+++ b/pkg/utils/handoff_windows.go
@@ -1,0 +1,189 @@
+//go:build windows
+
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net"
+	"os"
+	"time"
+
+	"github.com/eraser-dev/eraser/api/unversioned"
+)
+
+// Windows has no filesystem FIFO, so the handoff runs over Unix domain sockets,
+// which Windows has supported since Server 2019. A socket preserves the three
+// properties the FIFO implementation relies on: Accept blocks until the peer
+// dials, the reader sees EOF when the peer closes, and the endpoint is a file,
+// so its absence still tells the remover that no scanner is present.
+//
+// Responsibility is inverted relative to Unix. With a FIFO the writer creates
+// the endpoint and the reader polls for it; with a socket the reader listens and
+// the writer dials with retry.
+
+// maxSocketPath is the sun_path limit. Exceeding it fails deep inside the
+// syscall with an opaque error, so it is checked up front.
+const maxSocketPath = 108
+
+// CompletionPipe is an endpoint a peer can observe before anything is read from
+// it. The scanner creates one early precisely so the remover can tell a scanner
+// is present, which means the listener has to outlive its creation.
+type CompletionPipe struct {
+	path string
+	l    net.Listener
+}
+
+// CreateCompletionPipe publishes the endpoint without waiting for a peer.
+func CreateCompletionPipe(path string) (*CompletionPipe, error) {
+	l, err := listen(path)
+	if err != nil {
+		return nil, err
+	}
+	return &CompletionPipe{path: path, l: l}, nil
+}
+
+// Await blocks until a peer signals completion. The payload is returned
+// unvalidated so callers keep their existing handling of unexpected content.
+func (p *CompletionPipe) Await() ([]byte, error) {
+	conn, err := p.l.Accept()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	return io.ReadAll(conn)
+}
+
+// Close releases the endpoint, which also unpublishes it.
+func (p *CompletionPipe) Close() error {
+	if p.l == nil {
+		return nil
+	}
+	return p.l.Close()
+}
+
+// WriteImagesPipe blocks until the reader is listening, then sends the list.
+// The unbounded retry mirrors the Unix implementation, where opening a FIFO for
+// writing blocks until a reader arrives.
+func WriteImagesPipe(path string, images []unversioned.Image) error {
+	data, err := json.Marshal(images)
+	if err != nil {
+		return err
+	}
+
+	conn, err := dialForever(path)
+	if err != nil {
+		return err
+	}
+
+	if _, err := conn.Write(data); err != nil {
+		_ = conn.Close()
+		return err
+	}
+
+	// closing is what signals end-of-message to the reader
+	return conn.Close()
+}
+
+// ReadImagesPipe publishes the endpoint and waits for the writer to connect and
+// finish. It returns ctx.Err() if the context is canceled while waiting.
+func ReadImagesPipe(ctx context.Context, path string) ([]unversioned.Image, error) {
+	l, err := listen(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = l.Close() }()
+
+	// Accept has no context form; closing the listener is what unblocks it
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = l.Close()
+		case <-done:
+		}
+	}()
+
+	conn, err := l.Accept()
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	data, err := io.ReadAll(conn)
+	if err != nil {
+		return nil, err
+	}
+
+	images := []unversioned.Image{}
+	if err := json.Unmarshal(data, &images); err != nil {
+		return nil, err
+	}
+
+	return images, nil
+}
+
+// WriteCompletionPipe signals a peer that this stage is done. The returned error
+// satisfies os.IsNotExist when the peer never published the endpoint, which is
+// how an absent scanner is detected.
+func WriteCompletionPipe(path string) error {
+	// Dialing a socket that is not there reports connection-refused on Windows
+	// rather than ENOENT, so the filesystem is the only reliable way to tell
+	// "never published" from "published but gone".
+	if _, err := os.Stat(path); err != nil {
+		return err
+	}
+
+	conn, err := net.Dial("unix", path)
+	if err != nil {
+		return err
+	}
+
+	if _, err := conn.Write([]byte(EraseCompleteMessage)); err != nil {
+		_ = conn.Close()
+		return err
+	}
+
+	return conn.Close()
+}
+
+func listen(path string) (net.Listener, error) {
+	if len(path) > maxSocketPath {
+		return nil, fmt.Errorf("socket path %q is %d bytes, over the %d byte limit", path, len(path), maxSocketPath)
+	}
+
+	// a socket left behind by a previous run would fail the bind
+	if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, err
+	}
+
+	return net.Listen("unix", path)
+}
+
+// dialForever waits for the reader to start listening. Errors are not
+// classified: Windows reports a missing socket as connection-refused, so there
+// is no reliable "not yet" error to match on. Retrying unconditionally mirrors
+// the Unix implementation, where opening a FIFO for writing blocks until a
+// reader arrives.
+func dialForever(path string) (net.Conn, error) {
+	if len(path) > maxSocketPath {
+		return nil, fmt.Errorf("socket path %q is %d bytes, over the %d byte limit", path, len(path), maxSocketPath)
+	}
+
+	for {
+		conn, err := net.Dial("unix", path)
+		if err == nil {
+			return conn, nil
+		}
+		time.Sleep(time.Second)
+	}
+}

--- a/pkg/utils/handoff_windows.go
+++ b/pkg/utils/handoff_windows.go
@@ -26,9 +26,11 @@ import (
 // the endpoint and the reader polls for it; with a socket the reader listens and
 // the writer dials with retry.
 
-// maxSocketPath is the sun_path limit. Exceeding it fails deep inside the
-// syscall with an opaque error, so it is checked up front.
-const maxSocketPath = 108
+// maxSocketPath is the longest usable pathname. The sun_path field is 108
+// bytes and has to hold a terminating NUL, so 107 is the real ceiling.
+// Exceeding it fails deep inside the syscall with an opaque error, so it is
+// checked up front.
+const maxSocketPath = 107
 
 // CompletionPipe is an endpoint a peer can observe before anything is read from
 // it. The scanner creates one early precisely so the remover can tell a scanner
@@ -59,12 +61,16 @@ func (p *CompletionPipe) Await() ([]byte, error) {
 	return io.ReadAll(conn)
 }
 
-// Close releases the endpoint, which also unpublishes it.
+// Close releases the endpoint, which also unpublishes it. Callers both defer
+// this and close explicitly, so repeat calls report success rather than
+// net.ErrClosed.
 func (p *CompletionPipe) Close() error {
 	if p.l == nil {
 		return nil
 	}
-	return p.l.Close()
+	l := p.l
+	p.l = nil
+	return l.Close()
 }
 
 // WriteImagesPipe blocks until the reader is listening, then sends the list.

--- a/pkg/utils/platform_windows_test.go
+++ b/pkg/utils/platform_windows_test.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Microsoft/go-winio"
@@ -52,6 +54,28 @@ func TestGetAddressAndDialer(t *testing.T) {
 		if a != tc.addr || !errors.Is(e, tc.err) {
 			t.Errorf("getAddressAndDialer(%q) = (%q, %v), want (%q, %v)", tc.endpoint, a, e, tc.addr, tc.err)
 		}
+	}
+}
+
+// The guard exists to replace an opaque syscall failure with a clear message,
+// so the boundary it enforces has to be the real one.
+func TestSocketPathLimitBoundary(t *testing.T) {
+	dir := shortTempDir(t)
+
+	pathOfLen := func(n int) string {
+		return filepath.Join(dir, strings.Repeat("a", n-len(dir)-1))
+	}
+
+	atLimit := pathOfLen(maxSocketPath)
+	l, err := listen(atLimit)
+	if err != nil {
+		t.Fatalf("listen(%d-byte path) = %v, want success", len(atLimit), err)
+	}
+	_ = l.Close()
+
+	overLimit := pathOfLen(maxSocketPath + 1)
+	if _, err := listen(overLimit); err == nil {
+		t.Errorf("listen(%d-byte path) = nil, want the guard to reject it", len(overLimit))
 	}
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -5,12 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/url"
 	"os"
 	"strings"
-	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -329,68 +327,16 @@ func readConfigMap(path string) ([]string, error) {
 	return images, nil
 }
 
+// ReadCollectScanPipe is the scanner-facing spelling of ReadImagesPipe, kept
+// because custom scanners may call it directly.
 func ReadCollectScanPipe(ctx context.Context) ([]unversioned.Image, error) {
-	timer := time.NewTimer(time.Second)
-	if !timer.Stop() {
-		<-timer.C
-	}
-	defer timer.Stop()
-
-	var f *os.File
-	for {
-		var err error
-
-		f, err = os.OpenFile(CollectScanPath, os.O_RDONLY, 0)
-		if err == nil {
-			break
-		}
-		if !os.IsNotExist(err) {
-			return nil, err
-		}
-
-		timer.Reset(time.Second)
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-timer.C:
-			continue
-		}
-	}
-
-	// json data is list of []eraserv1.Image
-	data, err := io.ReadAll(f)
-	if err != nil {
-		return nil, err
-	}
-
-	allImages := []unversioned.Image{}
-	if err = json.Unmarshal(data, &allImages); err != nil {
-		return nil, err
-	}
-
-	return allImages, nil
+	return ReadImagesPipe(ctx, CollectScanPath)
 }
 
+// WriteScanErasePipe is the scanner-facing spelling of WriteImagesPipe, kept
+// because custom scanners may call it directly.
 func WriteScanErasePipe(vulnerableImages []unversioned.Image) error {
-	data, err := json.Marshal(vulnerableImages)
-	if err != nil {
-		return err
-	}
-
-	if err = mkfifo(ScanErasePath, PipeMode); err != nil {
-		return err
-	}
-
-	file, err := os.OpenFile(ScanErasePath, os.O_WRONLY, 0)
-	if err != nil {
-		return err
-	}
-
-	if _, err := file.Write(data); err != nil {
-		return err
-	}
-
-	return file.Close()
+	return WriteImagesPipe(ScanErasePath, vulnerableImages)
 }
 
 func ProcessRepoDigests(repoDigests []string) ([]string, []error) {


### PR DESCRIPTION
> [!NOTE]
> Rebased onto `main` now that #1229 has merged, so the diff is now just this work: **8 files, three commits.**
>
> - `9daeb947` refactor: gather the worker handoff into `pkg/utils` — pure move, no behavior change
> - `ed03cad6` feat: run the worker handoff over Unix sockets on Windows
> - `8c925e11` fix: address review — socket path limit and `Close` idempotency
> - `118719d4` fix: address review — publish the collector completion endpoint before the payload

## What

Makes the collector -> scanner -> remover handoff work on Windows, which unblocks `pkg/collector` and `pkg/scanners/template` for `GOOS=windows`.

Continues the Windows work started in #1229.

## Why

The handoff is a set of Unix FIFOs, and the FIFO calls were written inline in three different packages:

| Package | What it did |
|---|---|
| `pkg/collector` | `unix.Mkfifo` + blocking `open` to hand images to the scanner, then a second FIFO to wait for the erase |
| `pkg/remover` | polled for the FIFO to appear, read it, then wrote completion back |
| `pkg/scanners/template` | `unix.Mkfifo` for its own completion endpoint |

So `golang.org/x/sys/unix` was imported by three packages that otherwise have nothing platform-specific in them, and any Windows story required touching all three. #1229 stopped at exactly this line for that reason.

## How

**First commit** moves the FIFO code behind an API in `pkg/utils` with no behaviour change. Linux is byte-for-byte the same syscall sequence:

```go
func CreateCompletionPipe(path string) (*CompletionPipe, error)
func (p *CompletionPipe) Await() ([]byte, error)
func (p *CompletionPipe) Close() error

func WriteImagesPipe(path string, images []unversioned.Image) error
func ReadImagesPipe(ctx context.Context, path string) ([]unversioned.Image, error)
func WriteCompletionPipe(path string) error
```

`CompletionPipe` is a type rather than a function because the scanner has to *publish* its endpoint early and *read* it much later — that gap is the whole mechanism by which the remover detects that a scanner is present.

**Second commit** adds `handoff_windows.go`. Windows has no filesystem FIFO, so the transport is a **Unix domain socket**, supported since Windows Server 2019 and reachable through plain `net.Listen("unix", ...)` / `net.Dial("unix", ...)`.

A socket preserves the three properties the FIFO implementation leans on:

| FIFO property | Socket equivalent |
|---|---|
| `open()` blocks until the peer arrives | `Accept` blocks; the writer dials with retry |
| reader sees EOF when the writer closes | `io.ReadAll` returns on close |
| endpoint is a file, so absence is observable | socket is a file, so `os.Stat` still answers |

Responsibility is inverted: with a FIFO the *writer* creates the endpoint and the reader polls for it; with a socket the *reader* listens and the writer dials.

### Why not named pipes

#1229 already vendors `go-winio`, so a named pipe was the obvious choice. Unix sockets won on three counts:

- **No new dependency in this path.** `net` covers it; `go-winio` stays confined to CRI dialing.
- **The endpoint stays pod-scoped.** A named pipe is a machine-global object in `\\.\pipe\`; a socket is a file in the pod's shared volume, so two ImageJobs on one node cannot collide, and nothing on the node can connect to it.
- **`os.IsNotExist` keeps working.** `pkg/remover` distinguishes "scanner disabled" from a real failure by that check. A missing pipe reports something else entirely.

The tradeoff is that the socket path is subject to the `sun_path` limit, so `listen` and `dialForever` check it up front rather than failing deep inside the syscall with an opaque error. The field is 108 bytes including the terminating NUL, so a pathname can use at most **107** — verified by probing `net.Listen` directly on Windows, where 107 binds and 108 returns `bind: invalid argument`.

## Not a breaking change

- **Linux is untouched at runtime, with one deliberate exception.** Same `mkfifo` calls, same modes, same blocking semantics; the code moved between packages without changing. The exception is `118719d4`, which reorders two calls in the collector to close a pre-existing race — see below.
- **No exported symbol removed.** `ReadCollectScanPipe` and `WriteScanErasePipe` are kept as thin wrappers, since out-of-tree scanners may call them.
- **No CRD, config schema or generated code touched.**
- **Nothing is scheduled onto Windows nodes by this PR.** The manager still emits Linux-shaped ImageJob pod specs. This is a prerequisite, not an enablement.

## One pre-existing race, fixed here

Review caught that the collector handed over the image list and only *then* created the endpoint it waits on:

```go
WriteImagesPipe(path, finalImages)                     // peer can now finish...
CreateCompletionPipe(util.EraseCompleteCollectPath)    // ...before this exists
```

If the peer reads the list and signals completion before that endpoint is published, the remover's completion write fails and it calls `os.Exit`, while the collector blocks in `Await` forever — a hung pod with a failed container.

Two things worth being precise about:

- **This is pre-existing on `main`, and it is not Windows-specific.** A FIFO that has not been created yet reports `ENOENT` from `open()` exactly as a missing socket reports it from `stat()`. The window is one syscall wide on either platform, which is why it has not been hit in practice.
- **The scanner already gets this right** — `ReceiveImages` publishes `EraseCompleteScanPath` before reading. The collector was the odd one out, so the fix makes it consistent rather than introducing a new convention.

I'd normally leave a pre-existing bug out of a port PR, but this one is four lines, sits in code this PR already rewrites, and deadlocks a pod when it fires.

## Testing

**Unit** — `pkg/utils/handoff_test.go` deliberately carries *no* build tag, so the same four tests run against whichever implementation the platform selects: images round-trip, completion round-trip, absent peer reports `os.IsNotExist`, and `Close` is safe to call twice.

**Cross-compile** — `GOOS=windows go build ./pkg/...` now succeeds for `pkg/collector` and `pkg/scanners/template`, which it did not before.

**On a real node** — see below.

## Standalone E2E test results

Upstream has no Windows CI, so this was validated on a personal fork against a real AKS Windows Server 2022 node.

<details>
<summary><b>Harness</b> — where the tooling lives</summary>

| | |
|---|---|
| Cross-container handoff harness | [`hack/ipcspike`](https://github.com/charleswool/eraser/blob/main/hack/ipcspike/main.go) |
| Build + unit workflow | [`.github/workflows/windows-ci.yaml`](https://github.com/charleswool/eraser/blob/main/.github/workflows/windows-ci.yaml) |
| Manual E2E runner | [`hack/windows-e2e.ps1`](https://github.com/charleswool/eraser/blob/main/hack/windows-e2e.ps1) |

Unit tests exercise the handoff inside one process, which is not the question that matters. The collector, scanner and remover are separate containers sharing a volume, so `ipcspike` runs **this PR's actual `pkg/utils` API** from two containers of one pod over an `emptyDir`:

- `producer` (collector-shaped) publishes its completion endpoint, hands over an image list, then waits to be told the erase finished
- `consumer` (remover-shaped) reads the list, checks that an endpoint nobody published is still reported as `IsNotExist`, then signals back

</details>

<details>
<summary><b>Environment</b></summary>

| | |
|---|---|
| Cluster | AKS 1.35.6 |
| Node | Windows Server 2022 Datacenter, build 10.0.20348.5386 |
| Runtime | containerd 1.7.20+azure |
| Pod | HostProcess, base `mcr.microsoft.com/windows/nanoserver:ltsc2022` |
| Identity | `runAsUserName: NT AUTHORITY\SYSTEM` |
| Shared volume | `emptyDir` mounted into both containers |

</details>

<details>
<summary><b>Live results</b> — run against the code in <code>ed03cad6</code></summary>

Cross-container handoff, two containers of one pod over an `emptyDir`:

```text
=== consumer ===
consumer   dir            : C:\eraser-shared
consumer   ReadImagesPipe : OK 2 images in 18.008s
consumer     sha256:aaa [mcr.microsoft.com/windows/servercore:ltsc2022]
consumer     sha256:bbb [mcr.microsoft.com/windows/nanoserver:ltsc2022]
consumer   absent peer    : OK reported as IsNotExist
consumer   WriteCompletion: OK
RESULT consumer: PASS

=== producer ===
producer   dir            : C:\eraser-shared
producer   WriteImagesPipe: OK 2 images in 1ms
producer   Await          : OK "complete" after 1ms
RESULT producer: PASS
```

The 18s on the consumer side is the deliberate 20s stagger in the producer container's command; it is the listener waiting, not latency.

The package's own tests, cross-compiled for `windows/amd64` and run on the same node:

```text
Microsoft Windows [Version 10.0.20348.5386]

=== RUN   TestImagesHandoffRoundTrip
--- PASS: TestImagesHandoffRoundTrip (1.01s)
=== RUN   TestCompletionHandoffRoundTrip
--- PASS: TestCompletionHandoffRoundTrip (0.00s)
=== RUN   TestWriteCompletionPipeAbsentPeerIsNotExist
--- PASS: TestWriteCompletionPipeAbsentPeerIsNotExist (0.00s)
=== RUN   TestCompletionPipeCloseIsIdempotentlySafe
--- PASS: TestCompletionPipeCloseIsIdempotentlySafe (0.00s)
=== RUN   TestGetAddressAndDialer
--- PASS: TestGetAddressAndDialer (0.00s)
=== RUN   TestMkfifoUnsupported
--- PASS: TestMkfifoUnsupported (0.00s)
=== RUN   TestNpipeDialerConnects
--- PASS: TestNpipeDialerConnects (0.01s)
=== RUN   TestParseEndpointWithFallBackProtocol
--- PASS: TestParseEndpointWithFallBackProtocol (0.00s)
=== RUN   TestParseEndpoint
--- PASS: TestParseEndpoint (0.00s)
PASS
```

</details>

<details>
<summary><b>Two observations from the run</b></summary>

**A missing Unix socket reports connection-refused on Windows, not `ENOENT`.** This is worth writing down because it is not what the Unix intuition predicts, and it initially hung a test. Dialing a path that does not exist gives `WSAECONNREFUSED` (10061), and none of the obvious checks match it:

```text
errors.Is(err, fs.ErrNotExist)      = false
os.IsNotExist(err)                  = false
errors.Is(err, syscall.ECONNREFUSED)= false   // Unix errno 111, not 10061
```

Two consequences, both in the code:

- `WriteCompletionPipe` uses `os.Stat` for the existence check rather than inferring it from the dial error, so `pkg/remover`'s `os.IsNotExist` branch keeps working unchanged.
- `dialForever` does **not** classify errors. There is no reliable "not yet" error to match on, so it retries unconditionally on a 1s tick — which is also what the Unix side effectively does by blocking in `open()`.

**Socket rendezvous is weaker than FIFO rendezvous.** `Dial` succeeds as soon as the listener exists, without a matching `Accept`, whereas a FIFO `open` does not return until the reader is actually there. In this flow it does not matter — the payload is small, it is written and the connection closed immediately, and the reader always calls `Accept` — but it is a real semantic difference rather than a drop-in equivalence, so I would rather state it than imply the two are identical.

</details>

## Follow-ups, not in this PR

- **OS-aware ImageJob pod specs.** The path constants in `pkg/utils` are still Linux-shaped (`/run/eraser.sh/shared-data/...`), and the manager still emits a Linux pod spec with a CRI `hostPath` mount. Windows needs a HostProcess `securityContext` and a Windows mount path. That is the next piece.
- **`pkg/remover`'s single 5-minute context** covering `ListImages` + `ListContainers` + *every* `DeleteImage`. Measured on this node, one large Windows image takes 15–74s to delete, so the budget is exhausted by roughly four images. Flagged in #1229 as well.
- **A pre-existing bug I deliberately did not fix:** `Finish()` in `pkg/scanners/template` returns `nil` when the completion payload is not the expected message. Silently succeeding on an unexpected payload looks wrong, but changing it is a behaviour change unrelated to this PR — happy to fix it separately if you agree it is a bug.

## One question for reviewers

`ReadCollectScanPipe` and `WriteScanErasePipe` are now one-line wrappers over `ReadImagesPipe` / `WriteImagesPipe`. I kept them because they are exported and an out-of-tree scanner could be calling them. If you would rather they were deprecated or dropped, say so and I will.
