### PR TITLE
fix: bump Go builder image to 1.26.6 to clear stdlib CVEs (repo-wide Trivy failure)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.6
 
-ARG GO_IMAGE="golang:1.26.5-bookworm@sha256:1ecb7edf62a0408027bd5729dfd6b1b8766e578e8df93995b225dfd0944eb651"
+ARG GO_IMAGE="golang:1.26.6-bookworm@sha256:116d58cbd88c1297624acc6e967a060012422bacf9930927e23fb719189c6f36"
 # Use the upstream Trivy release image rather than rebuilding its binary with
 # local dependency overrides.
 ARG TRIVY_BINARY_IMG="ghcr.io/aquasecurity/trivy:0.72.0"

--- a/build/tooling/Dockerfile
+++ b/build/tooling/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5-bookworm@sha256:1ecb7edf62a0408027bd5729dfd6b1b8766e578e8df93995b225dfd0944eb651
+FROM golang:1.26.6-bookworm@sha256:116d58cbd88c1297624acc6e967a060012422bacf9930927e23fb719189c6f36
 
 # v0.16.4 is the minimum controller-gen release whose x/tools builds with Go 1.26.
 RUN GOTOOLCHAIN=local GO111MODULE=on go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.4


### PR DESCRIPTION
## Problem

**This is a repo-wide CI failure, not specific to any one PR.** The
`[Trivy] Scan for vulnerabilities` job currently fails on every open pull
request and on `main`, because the pinned Go builder image ships a Go
standard library with 8 fixed HIGH CVEs.

Example failure (from https://github.com/eraser-dev/eraser/actions/runs/32103803998/job/95795642843,
the `Run trivy for remover` step — the first Trivy step, so the job aborts
there and the other three images are never scanned):

```
Total: 8 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 8, CRITICAL: 0)

Library  Vulnerability   Severity  Status  Installed Version  Fixed Version
stdlib   CVE-2026-33818  HIGH      fixed   v1.26.5            1.25.13, 1.26.6, 1.27.0-rc.3
         CVE-2026-39821  HIGH      fixed   v1.26.5            1.26.6, 1.27.0-rc.3
         CVE-2026-46600  HIGH      fixed   v1.26.5            1.26.6, 1.27.0-rc.3
         CVE-2026-56853  HIGH      fixed   v1.26.5            1.25.13, 1.26.6, 1.27.0-rc.3
         CVE-2026-56858  HIGH      fixed   v1.26.5            1.26.6, 1.27.0-rc.3
         CVE-2026-56859  HIGH      fixed   v1.26.5            1.26.6, 1.27.0-rc.3
         CVE-2026-56860  HIGH      fixed   v1.26.5            1.26.6, 1.27.0-rc.3
         CVE-2026-56862  HIGH      fixed   v1.26.5            1.26.6, 1.27.0-rc.3
```

| CVE | Package |
| --- | --- |
| CVE-2026-33818 | `encoding/asn1` — denial of service |
| CVE-2026-39821 | `golang.org/x/net/idna` |
| CVE-2026-46600 | `golang.org/x/net/dns/dnsmessage` |
| CVE-2026-56853 | `net/http` — unencrypted HTTP/2 |
| CVE-2026-56858 | `html/template` — cross-site scripting |
| CVE-2026-56859 | `encoding/xml` — denial of service |
| CVE-2026-56860 | `net/url` — denial of service |
| CVE-2026-56862 | `crypto/tls` — denial of service |

All findings are in `stdlib`, i.e. the Go toolchain used to compile the
binaries, not in any module dependency. The version is determined entirely by
the pinned builder image, so no source or `go.mod` change can affect it.

`.github/workflows/test.yaml` runs Trivy with `exit-code: "1"` and
`ignore-unfixed: true`; every one of these is `fixed`, so the gate trips.

## Fix

Bump the pinned Go builder image from `1.26.5` to `1.26.6`, which is the first
release containing all eight fixes:

- `Dockerfile` — `ARG GO_IMAGE`
- `build/tooling/Dockerfile` — `FROM`

`go.mod` deliberately keeps `toolchain go1.26.5`. Neither Dockerfile sets
`GOTOOLCHAIN`, so it defaults to `auto`, under which a newer local toolchain is
used as-is and the directive is only a floor. No `go.mod` change is required.

## Verification

The failing job aborts at the first of four Trivy steps, so only `remover` is
directly demonstrated. The remaining three images are produced by the same
builder stage, so they are expected to clear as well — CI on this PR will
confirm.
