### PR TITLE
fix: write updated config back to mounted file on configmap reload

### DIFF
--- a/main.go
+++ b/main.go
@@ -308,6 +308,15 @@ func startConfigWatch(cancel context.CancelFunc, watcher *inotify.Watcher, erase
 				continue
 			}
 
+			// Write the updated configuration back to the mounted file so that
+			// containers (e.g. trivy scanner) reading the config file see the
+			// updated values instead of the stale file on disk.
+			if updatedBytes, err := yaml.Marshal(newConfig); err != nil {
+				setupLog.Error(err, "failed to marshal updated configuration")
+			} else if err = os.WriteFile(filename, updatedBytes, 0644); err != nil {
+				setupLog.Error(err, "failed to write updated configuration to file")
+			}
+
 			// read back the new configuration
 			*newConfig, err = eraserOpts.Read()
 			if err != nil {


### PR DESCRIPTION
Fixes #927

When Kubernetes updates a ConfigMap, the controller detects the change via inotify and updates its in-memory configuration. However, the trivy scanner pod reads the config file directly from the mounted volume, so it continues to see the stale version.

The bug:
1. ConfigMap is updated by admin
2. Controller detects IN_DELETE_SELF event and reads new config
3. Controller calls eraserOpts.Update(newConfig) to update in-memory state
4. But the mounted file on disk still contains the old config
5. Trivy scanner pod reading from the mount sees stale config

The fix:
After updating the in-memory config, write the marshaled config back to the mounted file. This ensures sidecar containers reading the config file see the updated values.

