### PR TITLE
feat: manager emits Windows ImageJob pods

### DIFF
--- a/controllers/imagejob/imagejob_controller.go
+++ b/controllers/imagejob/imagejob_controller.go
@@ -23,6 +23,7 @@ import (
 
 	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -56,6 +57,12 @@ const (
 	removerContainer     = "remover"
 	managerLabelValue    = "controller-manager"
 	managerLabelKey      = "control-plane"
+
+	windowsOS              = string(corev1.Windows)
+	windowsSandboxMountEnv = "%CONTAINER_SANDBOX_MOUNT_POINT%"
+	runtimeSockVolumeName  = "runtime-sock-volume"
+
+	windowsMinMemoryLimit = "256Mi"
 )
 
 var log = logf.Log.WithName("controller").WithValues("process", "imagejob-controller")
@@ -353,6 +360,9 @@ func (r *Reconciler) handleNewJob(ctx context.Context, imageJob *eraserv1.ImageJ
 		return errors.Errorf("invalid node filter option")
 	}
 
+	scannerEnabled := len(template.Template.Spec.Containers) > 2
+	nodeList, skipped = skipWindowsScannerNodes(nodeList, skipped, scannerEnabled)
+
 	imageJob.Status.Skipped = skipped
 	if err := r.updateJobStatus(ctx, imageJob); err != nil {
 		return err
@@ -461,6 +471,26 @@ func (r *Reconciler) updateJobStatus(ctx context.Context, imageJob *eraserv1.Ima
 	return nil
 }
 
+func skipWindowsScannerNodes(nodeList []corev1.Node, skipped int, scannerEnabled bool) ([]corev1.Node, int) {
+	if !scannerEnabled {
+		return nodeList, skipped
+	}
+
+	kept := make([]corev1.Node, 0, len(nodeList))
+	for i := range nodeList {
+		if isWindowsNode(&nodeList[i]) {
+			log.Info("windows node skipped because image scanning is enabled (scanner is not supported on windows yet)",
+				"nodeName", nodeList[i].Name,
+			)
+			skipped++
+			continue
+		}
+		kept = append(kept, nodeList[i])
+	}
+
+	return kept, skipped
+}
+
 func selectIncludedNodes(nodes *corev1.NodeList, includeNodesSelectors []string) ([]corev1.Node, int, error) {
 	skipped := 0
 	nodeList := make([]corev1.Node, 0, len(nodes.Items))
@@ -539,11 +569,11 @@ func copyAndFillTemplateSpec(templateSpecTemplate *corev1.PodSpec, env []corev1.
 	}
 
 	volumes := []corev1.Volume{
-		{Name: "runtime-sock-volume", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: u.Path}}},
+		{Name: runtimeSockVolumeName, VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: u.Path}}},
 	}
 
 	volumeMounts := []corev1.VolumeMount{
-		{MountPath: controllerUtils.CRIPath, Name: "runtime-sock-volume"},
+		{MountPath: controllerUtils.CRIPath, Name: runtimeSockVolumeName},
 	}
 
 	templateSpec := templateSpecTemplate.DeepCopy()
@@ -581,5 +611,137 @@ func copyAndFillTemplateSpec(templateSpecTemplate *corev1.PodSpec, env []corev1.
 	templateSpec.Volumes = append(volumes, templateSpec.Volumes...)
 	templateSpec.NodeName = nodeName
 
+	if isWindowsNode(node) {
+		// TODO(#1236): the Windows worker dials the fixed containerd named pipe
+		// and ignores runtimeSpec.Address. Propagate a configurable Windows
+		// runtime address to the worker (a named pipe can't be hostPath-mounted
+		// like a Linux socket) in a follow-up.
+		//
+		// Windows nodes with a scanner enabled are filtered out earlier (see
+		// handleNewJob), so a scanner container is never reached here.
+		fillWindowsPodSpec(templateSpec)
+	}
+
 	return templateSpec, nil
+}
+
+// isWindowsNode reports whether the node runs Windows, preferring the
+// kubernetes.io/os label and falling back to the reported node OS.
+func isWindowsNode(node *corev1.Node) bool {
+	if osName, ok := node.Labels[corev1.LabelOSStable]; ok {
+		return strings.EqualFold(osName, windowsOS)
+	}
+	return strings.EqualFold(node.Status.NodeInfo.OperatingSystem, windowsOS)
+}
+
+// fillWindowsPodSpec turns the Linux-shaped template into a Windows HostProcess
+// pod.
+func fillWindowsPodSpec(templateSpec *corev1.PodSpec) {
+	// Declare the pod's OS so the apiserver enforces Windows OS-field
+	// consistency (e.g. rejects leftover Linux-only securityContext fields).
+	templateSpec.OS = &corev1.PodOS{Name: corev1.Windows}
+	templateSpec.HostNetwork = true
+	templateSpec.SecurityContext = eraserUtils.WindowsHostProcessPodSecurityContext()
+
+	// A Windows named pipe can't be hostPath-mounted like a Linux socket, so
+	// drop the CRI socket volume added for Linux.
+	keptVolumes := templateSpec.Volumes[:0]
+	for i := range templateSpec.Volumes {
+		if templateSpec.Volumes[i].Name != runtimeSockVolumeName {
+			keptVolumes = append(keptVolumes, templateSpec.Volumes[i])
+		}
+	}
+	templateSpec.Volumes = keptVolumes
+
+	for i := range templateSpec.Containers {
+		c := &templateSpec.Containers[i]
+		// SharedSecurityContext sets Linux-only fields (capabilities,
+		// seccompProfile, readOnlyRootFilesystem) that are invalid on Windows.
+		c.SecurityContext = nil
+
+		// Ensure the Windows-safe minimum memory limit.
+		raiseWindowsMemoryLimit(c)
+
+		// TODO(#1236): the Windows worker command is derived from the container
+		// name (%CONTAINER_SANDBOX_MOUNT_POINT%\<name>.exe). This forces every
+		// BYO Windows worker image to ship a binary matching the container name.
+		// Make the command (and its args) configurable via the configmap
+		// instead of deriving it here.
+		c.Command = []string{windowsSandboxMountEnv + `\` + c.Name + ".exe"}
+
+		// Drop the CRI socket mount and translate the remaining eraser.sh mounts
+		// to their Windows form.
+		keptMounts := c.VolumeMounts[:0]
+		for j := range c.VolumeMounts {
+			if c.VolumeMounts[j].Name == runtimeSockVolumeName {
+				continue
+			}
+			c.VolumeMounts[j].MountPath = linuxToWindowsEraserPath(c.VolumeMounts[j].MountPath)
+			keptMounts = append(keptMounts, c.VolumeMounts[j])
+		}
+		c.VolumeMounts = keptMounts
+
+		for j := range c.Args {
+			c.Args[j] = translateEraserArg(c.Args[j])
+		}
+
+		// Windows HostProcess pods can't reach in-cluster telemetry endpoints
+		// (see disableWindowsTelemetry), so drop the OTLP endpoint here.
+		disableWindowsTelemetry(c)
+	}
+}
+
+const otlpEndpointEnvVar = "OTEL_EXPORTER_OTLP_ENDPOINT"
+
+func disableWindowsTelemetry(c *corev1.Container) {
+	for i := range c.Env {
+		if c.Env[i].Name == otlpEndpointEnvVar && c.Env[i].Value != "" {
+			log.Info("telemetry export is not supported on windows yet; clearing the OTLP endpoint on the windows worker (a HostProcess pod uses host DNS and cannot resolve in-cluster service endpoints)",
+				"container", c.Name,
+				"otlpEndpoint", c.Env[i].Value,
+			)
+			c.Env[i].Value = ""
+		}
+	}
+}
+
+// raiseWindowsMemoryLimit ensures a container's memory limit is at least the
+// Windows-safe minimum. An unset or zero limit is left as-is.
+func raiseWindowsMemoryLimit(c *corev1.Container) {
+	limit, ok := c.Resources.Limits[corev1.ResourceMemory]
+	// An unset or zero limit means no cap, so there is nothing to raise.
+	if !ok || limit.IsZero() {
+		return
+	}
+	floor := resource.MustParse(windowsMinMemoryLimit)
+	if req, ok := c.Resources.Requests[corev1.ResourceMemory]; ok && req.Cmp(floor) > 0 {
+		floor = req
+	}
+	if limit.Cmp(floor) < 0 {
+		c.Resources.Limits[corev1.ResourceMemory] = floor
+	}
+}
+
+// linuxToWindowsEraserPath rewrites an absolute eraser.sh path (e.g. the
+// shared-data emptyDir mount or the imagelist configmap mount) from its Linux
+// form to the Windows form.
+func linuxToWindowsEraserPath(p string) string {
+	if p == eraserUtils.LinuxEraserPath {
+		return eraserUtils.WindowsEraserPath
+	}
+	if strings.HasPrefix(p, eraserUtils.LinuxEraserPath+"/") {
+		rest := strings.ReplaceAll(strings.TrimPrefix(p, eraserUtils.LinuxEraserPath), "/", `\`)
+		return eraserUtils.WindowsEraserPath + rest
+	}
+	return p
+}
+
+// translateEraserArg rewrites an eraser.sh path embedded in a container arg or
+// command entry (e.g. "--imagelist=/run/eraser.sh/imagelist/images").
+func translateEraserArg(a string) string {
+	idx := strings.Index(a, eraserUtils.LinuxEraserPath)
+	if idx < 0 {
+		return a
+	}
+	return a[:idx] + linuxToWindowsEraserPath(a[idx:])
 }

--- a/controllers/imagejob/imagejob_controller_test.go
+++ b/controllers/imagejob/imagejob_controller_test.go
@@ -1,0 +1,366 @@
+package imagejob
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/eraser-dev/eraser/api/unversioned"
+	controllerUtils "github.com/eraser-dev/eraser/controllers/util"
+	eraserUtils "github.com/eraser-dev/eraser/pkg/utils"
+)
+
+// sharedDataMountPath mirrors the Linux path the collector controller bakes into
+// the pod template before the manager fills it per node.
+const sharedDataMountPath = eraserUtils.LinuxSharedDataPath
+
+func newTemplateSpec() *corev1.PodSpec {
+	return &corev1.PodSpec{
+		Volumes: []corev1.Volume{
+			{Name: "shared-data", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		},
+		Containers: []corev1.Container{
+			{
+				Name: "collector",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("25Mi")},
+					Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("30Mi")},
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					{MountPath: sharedDataMountPath, Name: "shared-data"},
+				},
+			},
+			{
+				Name: removerContainer,
+				Args: []string{"--imagelist=/run/eraser.sh/imagelist/images", "--log-level=info"},
+				VolumeMounts: []corev1.VolumeMount{
+					{MountPath: sharedDataMountPath, Name: "shared-data"},
+					{MountPath: "/run/eraser.sh/imagelist", Name: "imagelist"},
+				},
+				SecurityContext: eraserUtils.SharedSecurityContext,
+			},
+		},
+	}
+}
+
+func node(name, osLabel string) *corev1.Node {
+	n := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	if osLabel != "" {
+		n.Labels = map[string]string{corev1.LabelOSStable: osLabel}
+	}
+	return n
+}
+
+func runtimeSpec() *unversioned.RuntimeSpec {
+	return &unversioned.RuntimeSpec{
+		Name:    unversioned.RuntimeContainerd,
+		Address: "unix:///run/containerd/containerd.sock",
+	}
+}
+
+func hasVolume(spec *corev1.PodSpec, name string) bool {
+	for i := range spec.Volumes {
+		if spec.Volumes[i].Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func containerMountPath(c *corev1.Container, volumeName string) (string, bool) {
+	for i := range c.VolumeMounts {
+		if c.VolumeMounts[i].Name == volumeName {
+			return c.VolumeMounts[i].MountPath, true
+		}
+	}
+	return "", false
+}
+
+func TestCopyAndFillTemplateSpecLinux(t *testing.T) {
+	spec, err := copyAndFillTemplateSpec(newTemplateSpec(), nil, node("linux-node", "linux"), runtimeSpec())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if spec.NodeName != "linux-node" {
+		t.Errorf("NodeName = %q, want linux-node", spec.NodeName)
+	}
+	if spec.HostNetwork {
+		t.Error("HostNetwork should be false for a Linux node")
+	}
+	if spec.OS != nil {
+		t.Errorf("spec.OS should be unset on a Linux node, got %v", spec.OS)
+	}
+	if !hasVolume(spec, runtimeSockVolumeName) {
+		t.Errorf("expected CRI hostPath volume %q on a Linux node", runtimeSockVolumeName)
+	}
+	for i := range spec.Containers {
+		if p, ok := containerMountPath(&spec.Containers[i], runtimeSockVolumeName); !ok {
+			t.Errorf("container %q missing CRI mount", spec.Containers[i].Name)
+		} else if p != controllerUtils.CRIPath {
+			t.Errorf("CRI mount path = %q, want %q", p, controllerUtils.CRIPath)
+		}
+		if p, _ := containerMountPath(&spec.Containers[i], "shared-data"); p != eraserUtils.LinuxSharedDataPath {
+			t.Errorf("shared-data mount = %q, want Linux path %q", p, eraserUtils.LinuxSharedDataPath)
+		}
+	}
+	// Linux security context is preserved on the remover container.
+	sc := spec.Containers[1].SecurityContext
+	if sc == nil || sc.ReadOnlyRootFilesystem == nil || !*sc.ReadOnlyRootFilesystem {
+		t.Error("expected Linux SharedSecurityContext preserved on Linux node")
+	}
+}
+
+func TestCopyAndFillTemplateSpecWindows(t *testing.T) {
+	spec, err := copyAndFillTemplateSpec(newTemplateSpec(), nil, node("win-node", "windows"), runtimeSpec())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if spec.NodeName != "win-node" {
+		t.Errorf("NodeName = %q, want win-node", spec.NodeName)
+	}
+	if !spec.HostNetwork {
+		t.Error("HostNetwork should be true for a Windows HostProcess pod")
+	}
+	if spec.OS == nil || spec.OS.Name != corev1.Windows {
+		t.Errorf("spec.OS = %v, want Name=windows", spec.OS)
+	}
+	if hasVolume(spec, runtimeSockVolumeName) {
+		t.Error("CRI hostPath volume must be omitted on a Windows node")
+	}
+
+	if spec.SecurityContext == nil || spec.SecurityContext.WindowsOptions == nil {
+		t.Fatal("expected pod-level Windows HostProcess security context")
+	}
+	wo := spec.SecurityContext.WindowsOptions
+	if wo.HostProcess == nil || !*wo.HostProcess {
+		t.Error("HostProcess should be true")
+	}
+	if wo.RunAsUserName == nil || *wo.RunAsUserName != eraserUtils.WindowsHostProcessUserName {
+		t.Errorf("RunAsUserName = %v, want %q", wo.RunAsUserName, eraserUtils.WindowsHostProcessUserName)
+	}
+
+	for i := range spec.Containers {
+		c := &spec.Containers[i]
+		if _, ok := containerMountPath(c, runtimeSockVolumeName); ok {
+			t.Errorf("container %q should not have a CRI mount on Windows", c.Name)
+		}
+		if p, _ := containerMountPath(c, "shared-data"); p != eraserUtils.WindowsSharedDataPath {
+			t.Errorf("shared-data mount = %q, want Windows path %q", p, eraserUtils.WindowsSharedDataPath)
+		}
+		if c.SecurityContext != nil {
+			t.Errorf("container %q Linux SecurityContext should be cleared on Windows", c.Name)
+		}
+	}
+
+	// collector had a 30Mi memory limit (< 256Mi) -> raised to 256Mi; its 25Mi
+	// request is preserved.
+	col := &spec.Containers[0]
+	wantMin := resource.MustParse("256Mi")
+	if got := col.Resources.Limits[corev1.ResourceMemory]; got.Cmp(wantMin) != 0 {
+		t.Errorf("collector memory limit = %s, want 256Mi", got.String())
+	}
+	if got := col.Resources.Requests[corev1.ResourceMemory]; got.Cmp(resource.MustParse("25Mi")) != 0 {
+		t.Errorf("collector memory request = %s, want 25Mi (unchanged)", got.String())
+	}
+
+	// remover had no memory limit -> left unset (no Job Object memory cap).
+	rmv := &spec.Containers[1]
+	if _, ok := rmv.Resources.Limits[corev1.ResourceMemory]; ok {
+		t.Error("remover had no memory limit; it should stay unset on Windows")
+	}
+
+	// The remover's imagelist mount and --imagelist arg must be rewritten to Windows paths.
+	rem := &spec.Containers[1]
+	if p, _ := containerMountPath(rem, "imagelist"); p != `C:\run\eraser.sh\imagelist` {
+		t.Errorf("imagelist mount = %q, want C:\\run\\eraser.sh\\imagelist", p)
+	}
+	if rem.Args[0] != `--imagelist=C:\run\eraser.sh\imagelist\images` {
+		t.Errorf("imagelist arg = %q, want windows form", rem.Args[0])
+	}
+	if rem.Args[1] != "--log-level=info" {
+		t.Errorf("non-path arg should be untouched, got %q", rem.Args[1])
+	}
+	// HostProcess containers need an explicit sandbox-relative command.
+	wantCmd := `%CONTAINER_SANDBOX_MOUNT_POINT%\remover.exe`
+	if len(rem.Command) != 1 || rem.Command[0] != wantCmd {
+		t.Errorf("remover command = %v, want [%s]", rem.Command, wantCmd)
+	}
+}
+
+func TestSkipWindowsScannerNodes(t *testing.T) {
+	newNodes := func() []corev1.Node {
+		return []corev1.Node{
+			*node("linux-node", "linux"),
+			*node("win-node", "windows"),
+		}
+	}
+
+	t.Run("scanner enabled skips windows node", func(t *testing.T) {
+		kept, skipped := skipWindowsScannerNodes(newNodes(), 0, true)
+		if skipped != 1 {
+			t.Errorf("skipped = %d, want 1 (the windows node)", skipped)
+		}
+		if len(kept) != 1 || kept[0].Name != "linux-node" {
+			names := make([]string, len(kept))
+			for i := range kept {
+				names[i] = kept[i].Name
+			}
+			t.Errorf("kept nodes = %v, want [linux-node]", names)
+		}
+	})
+
+	t.Run("scanner enabled preserves prior skipped count", func(t *testing.T) {
+		_, skipped := skipWindowsScannerNodes(newNodes(), 3, true)
+		if skipped != 4 {
+			t.Errorf("skipped = %d, want 4 (3 prior + 1 windows)", skipped)
+		}
+	})
+
+	t.Run("scanner disabled keeps all nodes", func(t *testing.T) {
+		kept, skipped := skipWindowsScannerNodes(newNodes(), 0, false)
+		if len(kept) != 2 || skipped != 0 {
+			t.Errorf("got kept=%d skipped=%d, want both nodes kept", len(kept), skipped)
+		}
+	})
+}
+
+func TestFillWindowsPodSpecDisablesTelemetry(t *testing.T) {
+	spec := newTemplateSpec()
+	// The manager injects the OTLP endpoint on worker containers; here the
+	// remover container carries a cluster service-style endpoint.
+	spec.Containers[1].Env = append(spec.Containers[1].Env, corev1.EnvVar{
+		Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
+		Value: "otel-collector:4318",
+	})
+
+	fillWindowsPodSpec(spec)
+
+	found := false
+	for i := range spec.Containers {
+		for _, e := range spec.Containers[i].Env {
+			if e.Name == "OTEL_EXPORTER_OTLP_ENDPOINT" {
+				found = true
+				if e.Value != "" {
+					t.Errorf("container %q OTLP endpoint = %q, want cleared on windows", spec.Containers[i].Name, e.Value)
+				}
+			}
+		}
+	}
+	if !found {
+		t.Error("expected the OTLP endpoint env var to be present (and cleared), but it was missing")
+	}
+}
+
+func TestRaiseWindowsMemoryLimit(t *testing.T) {
+	cases := []struct {
+		name    string
+		limit   *string // nil = unset
+		request *string // nil = unset
+		want    *string // nil = still unset
+	}{
+		{"below min is raised", ptr("30Mi"), nil, ptr("256Mi")},
+		{"at min is unchanged", ptr("256Mi"), nil, ptr("256Mi")},
+		{"above min is unchanged", ptr("512Mi"), nil, ptr("512Mi")},
+		{"explicit zero stays unlimited", ptr("0"), nil, ptr("0")},
+		{"unset stays unset", nil, nil, nil},
+		{"floor is at least the request", ptr("30Mi"), ptr("300Mi"), ptr("300Mi")},
+		{"request below min still floors at min", ptr("30Mi"), ptr("100Mi"), ptr("256Mi")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &corev1.Container{}
+			if tc.limit != nil {
+				c.Resources.Limits = corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(*tc.limit)}
+			}
+			if tc.request != nil {
+				c.Resources.Requests = corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(*tc.request)}
+			}
+			raiseWindowsMemoryLimit(c)
+			got, ok := c.Resources.Limits[corev1.ResourceMemory]
+			if tc.want == nil {
+				if ok {
+					t.Errorf("memory limit = %s, want unset", got.String())
+				}
+				return
+			}
+			if !ok || got.Cmp(resource.MustParse(*tc.want)) != 0 {
+				t.Errorf("memory limit = %v, want %s", got, *tc.want)
+			}
+		})
+	}
+}
+
+func ptr(s string) *string { return &s }
+
+func TestIsWindowsNode(t *testing.T) {
+	cases := []struct {
+		name string
+		node *corev1.Node
+		want bool
+	}{
+		{"label windows", node("a", "windows"), true},
+		{"label linux", node("b", "linux"), false},
+		{"no label falls back to nodeinfo", &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "c"},
+			Status:     corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{OperatingSystem: "windows"}},
+		}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isWindowsNode(tc.node); got != tc.want {
+				t.Errorf("isWindowsNode = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLinuxToWindowsEraserPath(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"exact eraser path", "/run/eraser.sh", `C:\run\eraser.sh`},
+		{"file under eraser dir", "/run/eraser.sh/imagelist/images", `C:\run\eraser.sh\imagelist\images`},
+		{"trailing slash", "/run/eraser.sh/", `C:\run\eraser.sh\`},
+		// Sibling paths that only share the textual prefix must be left intact.
+		{"sibling dir suffix", "/run/eraser.sh-old/imagelist", "/run/eraser.sh-old/imagelist"},
+		{"sibling file suffix", "/run/eraser.shx", "/run/eraser.shx"},
+		{"unrelated path", "/var/lib/foo", "/var/lib/foo"},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := linuxToWindowsEraserPath(tc.in); got != tc.want {
+				t.Errorf("linuxToWindowsEraserPath(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTranslateEraserArg(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare path", "/run/eraser.sh/imagelist/images", `C:\run\eraser.sh\imagelist\images`},
+		{"flag with path", "--imagelist=/run/eraser.sh/imagelist/images", `--imagelist=C:\run\eraser.sh\imagelist\images`},
+		{"flag with exact path", "--dir=/run/eraser.sh", `--dir=C:\run\eraser.sh`},
+		{"non-path arg untouched", "--log-level=info", "--log-level=info"},
+		// Sibling path embedded in an arg must not be rewritten.
+		{"sibling path in flag", "--imagelist=/run/eraser.sh-old/imagelist", "--imagelist=/run/eraser.sh-old/imagelist"},
+		{"sibling file suffix", "--path=/run/eraser.shx", "--path=/run/eraser.shx"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := translateEraserArg(tc.in); got != tc.want {
+				t.Errorf("translateEraserArg(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/controllers/imagejob/imagejob_windows_validation_test.go
+++ b/controllers/imagejob/imagejob_windows_validation_test.go
@@ -1,0 +1,133 @@
+package imagejob
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+// startEnvtest brings up a real kube-apiserver + etcd so that emitted pod specs
+// can be checked against the apiserver's own validation (dry-run create). It is
+// skipped when the envtest binaries are not available (KUBEBUILDER_ASSETS unset),
+// so `go test` still works without them; `make test` sets that variable.
+func startEnvtest(t *testing.T) (client.Client, func()) {
+	t.Helper()
+
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		t.Skip("KUBEBUILDER_ASSETS not set; skipping apiserver validation test (run via `make test`)")
+	}
+
+	testEnv := &envtest.Environment{}
+	cfg, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("failed to start envtest: %v", err)
+	}
+
+	cl, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		_ = testEnv.Stop()
+		t.Fatalf("failed to build client: %v", err)
+	}
+
+	return cl, func() { _ = testEnv.Stop() }
+}
+
+func windowsPod(spec *corev1.PodSpec) *corev1.Pod {
+	// NodeName is set by the manager, but a dry-run create against the apiserver
+	// should validate the spec without a real node; clear it to avoid binding.
+	s := spec.DeepCopy()
+	s.NodeName = ""
+
+	// Fill fields the manager does not touch but the apiserver requires, so the
+	// test exercises OS validation rather than unrelated required-field errors.
+	backed := map[string]bool{}
+	for i := range s.Volumes {
+		backed[s.Volumes[i].Name] = true
+	}
+	for i := range s.Containers {
+		if s.Containers[i].Image == "" {
+			s.Containers[i].Image = "example.invalid/image:latest"
+		}
+		for _, vm := range s.Containers[i].VolumeMounts {
+			if vm.Name == "" || backed[vm.Name] {
+				continue
+			}
+			s.Volumes = append(s.Volumes, corev1.Volume{
+				Name:         vm.Name,
+				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+			})
+			backed[vm.Name] = true
+		}
+	}
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "eraser-win-validate-",
+			Namespace:    "default",
+		},
+		Spec: *s,
+	}
+}
+
+// TestWindowsPodSpecPassesAPIServerValidation is a guardrail: the Windows pod
+// spec the manager emits must be accepted by the Kubernetes apiserver. Because
+// the spec declares spec.os.name=windows, the apiserver runs validateOSFields,
+// which rejects Linux-only fields. If a future change adds a Windows-unsupported
+// field to the emitted spec, this test fails at admission rather than the break
+// only surfacing on a live Windows node.
+func TestWindowsPodSpecPassesAPIServerValidation(t *testing.T) {
+	cl, stop := startEnvtest(t)
+	defer stop()
+
+	spec, err := copyAndFillTemplateSpec(newTemplateSpec(), nil, node("win-node", "windows"), runtimeSpec())
+	if err != nil {
+		t.Fatalf("copyAndFillTemplateSpec: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pod := windowsPod(spec)
+	if err := cl.Create(ctx, pod, client.DryRunAll); err != nil {
+		t.Fatalf("apiserver rejected the emitted Windows pod spec: %v", err)
+	}
+}
+
+// TestWindowsPodSpecRejectsLinuxOnlyField proves the guardrail has teeth: a
+// Windows pod carrying a Linux-only container field (capabilities, exactly what
+// SharedSecurityContext sets) must be rejected by the apiserver. This is what
+// catches a regression where someone forgets to clear a Linux-only field on the
+// Windows path.
+func TestWindowsPodSpecRejectsLinuxOnlyField(t *testing.T) {
+	cl, stop := startEnvtest(t)
+	defer stop()
+
+	spec, err := copyAndFillTemplateSpec(newTemplateSpec(), nil, node("win-node", "windows"), runtimeSpec())
+	if err != nil {
+		t.Fatalf("copyAndFillTemplateSpec: %v", err)
+	}
+
+	// Re-introduce a Linux-only field on a container, simulating a regression.
+	spec.Containers[0].SecurityContext = &corev1.SecurityContext{
+		Capabilities: &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err = cl.Create(ctx, windowsPod(spec), client.DryRunAll)
+	if err == nil {
+		t.Fatal("expected apiserver to reject a Windows pod with a Linux-only capabilities field, but it was accepted")
+	}
+	if !apierrors.IsInvalid(err) {
+		t.Fatalf("expected an Invalid validation error, got: %v", err)
+	}
+}

--- a/docs/docs/customization.md
+++ b/docs/docs/customization.md
@@ -81,6 +81,11 @@ Only do that if the images configured under `components` can actually run on
 those nodes. Windows support is still in progress, so for now this is useful
 mainly when supplying your own images.
 
+Note that when the scanner is enabled, Windows nodes are skipped because the
+default scanner (Trivy) is Linux-only; Windows image removal only runs with the
+scanner disabled or when triggered manually via an
+_ImageList_.
+
 ### Configuring Components
 
 An _ImageJob_ is made up of various sub-jobs, with one sub-job for each node.

--- a/pkg/utils/security_context.go
+++ b/pkg/utils/security_context.go
@@ -15,3 +15,16 @@ var SharedSecurityContext = &corev1.SecurityContext{
 		Type: corev1.SeccompProfileTypeRuntimeDefault,
 	},
 }
+
+const WindowsHostProcessUserName = `NT AUTHORITY\SYSTEM`
+
+func WindowsHostProcessPodSecurityContext() *corev1.PodSecurityContext {
+	hostProcess := true
+	userName := WindowsHostProcessUserName
+	return &corev1.PodSecurityContext{
+		WindowsOptions: &corev1.WindowsSecurityContextOptions{
+			HostProcess:   &hostProcess,
+			RunAsUserName: &userName,
+		},
+	}
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -24,6 +24,12 @@ const (
 	PipeMode             = 0o644
 	EraseCompleteMessage = "complete"
 
+	LinuxEraserPath   = "/run/eraser.sh"
+	WindowsEraserPath = `C:\run\eraser.sh`
+
+	LinuxSharedDataPath   = LinuxEraserPath + "/shared-data"
+	WindowsSharedDataPath = WindowsEraserPath + `\shared-data`
+
 	EnvEraserRuntimeName = "ERASER_RUNTIME_NAME"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
## Summary
copyAndFillTemplateSpec now branches on the node's `kubernetes.io/os`:

**Windows nodes** produce a HostProcess pod spec:
- Pod-level HostProcess security context, `runAsUserName: NT AUTHORITY\SYSTEM`, `hostNetwork: true`.
- Drops the Linux-only `SharedSecurityContext` (capabilities / seccompProfile / readOnlyRootFilesystem are invalid on Windows).
- Omits the CRI hostPath volume + mount — a HostProcess pod reaches the containerd named pipe directly.
- Rewrites the shared-data emptyDir mount to its Windows form (`C:\run\eraser.sh\shared-data`).

**Linux nodes** keep existing behavior (refactored into `fillLinuxPodSpec`).

## Supporting changes
- `pkg/utils`: non build-tagged `LinuxSharedDataPath` / `WindowsSharedDataPath` constants + `SharedDataPathForOS` helper so the Linux-run manager can emit the Windows path; `WindowsHostProcessPodSecurityContext` + `WindowsHostProcessUserName`.
- New `imagejob_controller_test.go` covering Linux spec, Windows spec, and node OS detection.

## Validation
- `GOOS=linux go build ./...` / `go vet ./...` pass
- `go test ./controllers/imagejob/... ./pkg/utils/...` pass
- gofmt clean

## Follow-ups (out of scope here)
- Align the Windows shared-data path with the worker IPC constants (coordination with Charles).
- Windows Dockerfile stage / `PLATFORM` extension.


**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
