### PR TITLE
feat: make Windows worker CRI address configurable

### DIFF
--- a/api/unversioned/eraserconfig_types.go
+++ b/api/unversioned/eraserconfig_types.go
@@ -34,6 +34,12 @@ type (
 	RuntimeSpec struct {
 		Name    Runtime `json:"name"`
 		Address string  `json:"address"`
+		// WindowsAddress is the CRI endpoint used by workers scheduled on
+		// Windows nodes. Windows containerd is exposed through a named pipe that
+		// cannot be hostPath-mounted like a Linux socket, so the manager
+		// propagates this value to Windows workers via an environment variable
+		// instead of a volume mount. Defaults to the containerd named pipe.
+		WindowsAddress string `json:"windowsAddress,omitempty"`
 	}
 )
 
@@ -46,6 +52,10 @@ const (
 	ContainerdPath = "/run/containerd/containerd.sock"
 	DockerPath     = "/run/dockershim.sock"
 	CrioPath       = "/run/crio/crio.sock"
+
+	// DefaultWindowsRuntimeAddress is the containerd named pipe used by Windows
+	// workers when no WindowsAddress is configured.
+	DefaultWindowsRuntimeAddress = `npipe://./pipe/containerd-containerd`
 )
 
 func ConvertRuntimeToRuntimeSpec(r Runtime) (RuntimeSpec, error) {
@@ -88,8 +98,9 @@ func (td *Duration) MarshalJSON() ([]byte, error) {
 func (r *RuntimeSpec) UnmarshalJSON(b []byte) error {
 	// create temp RuntimeSpec to prevent recursive error into this function when using unmarshall to check validity of provided RuntimeSpec
 	type TempRuntimeSpec struct {
-		Name    string `json:"name"`
-		Address string `json:"address"`
+		Name           string `json:"name"`
+		Address        string `json:"address"`
+		WindowsAddress string `json:"windowsAddress"`
 	}
 	var rs TempRuntimeSpec
 	err := json.Unmarshal(b, &rs)
@@ -115,17 +126,15 @@ func (r *RuntimeSpec) UnmarshalJSON(b []byte) error {
 
 			r.Name = Runtime(rs.Name)
 			r.Address = rs.Address
+		} else {
+			// if RuntimeAddress is not provided, get defaults
+			converted, err := ConvertRuntimeToRuntimeSpec(rt)
+			if err != nil {
+				return err
+			}
 
-			return nil
+			*r = converted
 		}
-
-		// if RuntimeAddress is not provided, get defaults
-		converted, err := ConvertRuntimeToRuntimeSpec(rt)
-		if err != nil {
-			return err
-		}
-
-		*r = converted
 	case RuntimeNotProvided:
 		if rs.Address != "" {
 			return fmt.Errorf("runtime name must be provided with address")
@@ -138,7 +147,35 @@ func (r *RuntimeSpec) UnmarshalJSON(b []byte) error {
 		return fmt.Errorf("invalid runtime: valid names are %s, %s, %s", RuntimeContainerd, RuntimeDockerShim, RuntimeCrio)
 	}
 
+	// resolve the Windows runtime address, defaulting to the containerd named
+	// pipe when it is not explicitly configured.
+	winAddr, err := resolveWindowsRuntimeAddress(rs.WindowsAddress)
+	if err != nil {
+		return err
+	}
+	r.WindowsAddress = winAddr
+
 	return nil
+}
+
+// resolveWindowsRuntimeAddress validates a user-provided Windows runtime
+// address and falls back to the containerd named pipe when none is given.
+func resolveWindowsRuntimeAddress(addr string) (string, error) {
+	if addr == "" {
+		return DefaultWindowsRuntimeAddress, nil
+	}
+
+	u, err := url.Parse(addr)
+	if err != nil {
+		return "", err
+	}
+
+	switch u.Scheme {
+	case "npipe", "tcp":
+		return addr, nil
+	default:
+		return "", fmt.Errorf("invalid windowsAddress scheme: valid schemes for the Windows runtime address are `npipe` and `tcp`")
+	}
 }
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/api/unversioned/eraserconfig_types_test.go
+++ b/api/unversioned/eraserconfig_types_test.go
@@ -1,0 +1,60 @@
+package unversioned
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRuntimeSpecWindowsAddress(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "defaults to containerd pipe when unset",
+			input: `{"name":"containerd","address":"unix:///run/containerd/containerd.sock"}`,
+			want:  DefaultWindowsRuntimeAddress,
+		},
+		{
+			name:  "defaults when only name is provided",
+			input: `{"name":"containerd"}`,
+			want:  DefaultWindowsRuntimeAddress,
+		},
+		{
+			name:  "custom named pipe is preserved",
+			input: `{"name":"containerd","windowsAddress":"npipe://./pipe/custom-containerd"}`,
+			want:  "npipe://./pipe/custom-containerd",
+		},
+		{
+			name:  "tcp endpoint is accepted",
+			input: `{"name":"containerd","windowsAddress":"tcp://127.0.0.1:3459"}`,
+			want:  "tcp://127.0.0.1:3459",
+		},
+		{
+			name:    "invalid scheme is rejected",
+			input:   `{"name":"containerd","windowsAddress":"unix:///run/containerd/containerd.sock"}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var rs RuntimeSpec
+			err := json.Unmarshal([]byte(tc.input), &rs)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got none (WindowsAddress=%q)", rs.WindowsAddress)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if rs.WindowsAddress != tc.want {
+				t.Errorf("WindowsAddress = %q, want %q", rs.WindowsAddress, tc.want)
+			}
+		})
+	}
+}

--- a/api/v1alpha3/eraserconfig_types.go
+++ b/api/v1alpha3/eraserconfig_types.go
@@ -34,6 +34,12 @@ type (
 	RuntimeSpec struct {
 		Name    Runtime `json:"name"`
 		Address string  `json:"address"`
+		// WindowsAddress is the CRI endpoint used by workers scheduled on
+		// Windows nodes. Windows containerd is exposed through a named pipe that
+		// cannot be hostPath-mounted like a Linux socket, so the manager
+		// propagates this value to Windows workers via an environment variable
+		// instead of a volume mount. Defaults to the containerd named pipe.
+		WindowsAddress string `json:"windowsAddress,omitempty"`
 	}
 )
 
@@ -46,6 +52,10 @@ const (
 	ContainerdPath = "/run/containerd/containerd.sock"
 	DockerPath     = "/run/dockershim.sock"
 	CrioPath       = "/run/crio/crio.sock"
+
+	// DefaultWindowsRuntimeAddress is the containerd named pipe used by Windows
+	// workers when no WindowsAddress is configured.
+	DefaultWindowsRuntimeAddress = `npipe://./pipe/containerd-containerd`
 )
 
 func ConvertRuntimeToRuntimeSpec(r Runtime) (RuntimeSpec, error) {
@@ -88,8 +98,9 @@ func (td *Duration) MarshalJSON() ([]byte, error) {
 func (r *RuntimeSpec) UnmarshalJSON(b []byte) error {
 	// create temp RuntimeSpec to prevent recursive error into this function when using unmarshall to check validity of provided RuntimeSpec
 	type TempRuntimeSpec struct {
-		Name    string `json:"name"`
-		Address string `json:"address"`
+		Name           string `json:"name"`
+		Address        string `json:"address"`
+		WindowsAddress string `json:"windowsAddress"`
 	}
 	var rs TempRuntimeSpec
 	err := json.Unmarshal(b, &rs)
@@ -115,17 +126,15 @@ func (r *RuntimeSpec) UnmarshalJSON(b []byte) error {
 
 			r.Name = Runtime(rs.Name)
 			r.Address = rs.Address
+		} else {
+			// if RuntimeAddress is not provided, get defaults
+			converted, err := ConvertRuntimeToRuntimeSpec(rt)
+			if err != nil {
+				return err
+			}
 
-			return nil
+			*r = converted
 		}
-
-		// if RuntimeAddress is not provided, get defaults
-		converted, err := ConvertRuntimeToRuntimeSpec(rt)
-		if err != nil {
-			return err
-		}
-
-		*r = converted
 	case RuntimeNotProvided:
 		if rs.Address != "" {
 			return fmt.Errorf("runtime name must be provided with address")
@@ -138,7 +147,35 @@ func (r *RuntimeSpec) UnmarshalJSON(b []byte) error {
 		return fmt.Errorf("invalid runtime: valid names are %s, %s, %s", RuntimeContainerd, RuntimeDockerShim, RuntimeCrio)
 	}
 
+	// resolve the Windows runtime address, defaulting to the containerd named
+	// pipe when it is not explicitly configured.
+	winAddr, err := resolveWindowsRuntimeAddress(rs.WindowsAddress)
+	if err != nil {
+		return err
+	}
+	r.WindowsAddress = winAddr
+
 	return nil
+}
+
+// resolveWindowsRuntimeAddress validates a user-provided Windows runtime
+// address and falls back to the containerd named pipe when none is given.
+func resolveWindowsRuntimeAddress(addr string) (string, error) {
+	if addr == "" {
+		return DefaultWindowsRuntimeAddress, nil
+	}
+
+	u, err := url.Parse(addr)
+	if err != nil {
+		return "", err
+	}
+
+	switch u.Scheme {
+	case "npipe", "tcp":
+		return addr, nil
+	default:
+		return "", fmt.Errorf("invalid windowsAddress scheme: valid schemes for the Windows runtime address are `npipe` and `tcp`")
+	}
 }
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -498,6 +498,7 @@ func Convert_unversioned_ResourceRequirements_To_v1alpha3_ResourceRequirements(i
 func autoConvert_v1alpha3_RuntimeSpec_To_unversioned_RuntimeSpec(in *RuntimeSpec, out *unversioned.RuntimeSpec, s conversion.Scope) error {
 	out.Name = unversioned.Runtime(in.Name)
 	out.Address = in.Address
+	out.WindowsAddress = in.WindowsAddress
 	return nil
 }
 
@@ -509,6 +510,7 @@ func Convert_v1alpha3_RuntimeSpec_To_unversioned_RuntimeSpec(in *RuntimeSpec, ou
 func autoConvert_unversioned_RuntimeSpec_To_v1alpha3_RuntimeSpec(in *unversioned.RuntimeSpec, out *RuntimeSpec, s conversion.Scope) error {
 	out.Name = Runtime(in.Name)
 	out.Address = in.Address
+	out.WindowsAddress = in.WindowsAddress
 	return nil
 }
 

--- a/controllers/imagejob/imagejob_controller.go
+++ b/controllers/imagejob/imagejob_controller.go
@@ -57,8 +57,9 @@ const (
 	managerLabelValue    = "controller-manager"
 	managerLabelKey      = "control-plane"
 
-	windowsOS             = "windows"
-	runtimeSockVolumeName = "runtime-sock-volume"
+	windowsOS              = "windows"
+	runtimeSockVolumeName  = "runtime-sock-volume"
+	windowsSandboxMountEnv = "%CONTAINER_SANDBOX_MOUNT_POINT%"
 )
 
 var log = logf.Log.WithName("controller").WithValues("process", "imagejob-controller")
@@ -615,8 +616,8 @@ func fillLinuxPodSpec(templateSpec *corev1.PodSpec, runtimeSpec *unversioned.Run
 // pod. A HostProcess pod runs in the host network namespace and reaches the
 // containerd named pipe directly, so no CRI hostPath volume or mount is added.
 // The Linux-only container security context is dropped in favor of a HostProcess
-// pod-level security context, and shared-data mount paths are rewritten to their
-// Windows form.
+// pod-level security context, and eraser.sh paths in mounts, args and commands
+// are rewritten to their Windows form.
 func fillWindowsPodSpec(templateSpec *corev1.PodSpec) {
 	templateSpec.HostNetwork = true
 	templateSpec.SecurityContext = eraserUtils.WindowsHostProcessPodSecurityContext()
@@ -626,16 +627,52 @@ func fillWindowsPodSpec(templateSpec *corev1.PodSpec) {
 		// SharedSecurityContext sets Linux-only fields (capabilities,
 		// seccompProfile, readOnlyRootFilesystem) that are invalid on Windows.
 		c.SecurityContext = nil
-		rewriteSharedDataMounts(c)
+
+		// Windows HostProcess containers run directly on the host and do not
+		// support CPU/memory requests or limits; leaving them set makes the
+		// container fail to start ("The system cannot execute the specified
+		// program").
+		c.Resources = corev1.ResourceRequirements{}
+
+		// A HostProcess container's binary lives under the ephemeral sandbox
+		// mount point, whose location is only known at runtime via the
+		// CONTAINER_SANDBOX_MOUNT_POINT environment variable. The kubelet
+		// expands that variable in the pod spec command (but not in a baked-in
+		// image ENTRYPOINT), so set an explicit command. Eraser's Windows worker
+		// images expose the binary as <container-name>.exe at the image root.
+		if len(c.Command) == 0 {
+			c.Command = []string{windowsSandboxMountEnv + `\` + c.Name + ".exe"}
+		}
+
+		for j := range c.VolumeMounts {
+			c.VolumeMounts[j].MountPath = linuxToWindowsEraserPath(c.VolumeMounts[j].MountPath)
+		}
+		for j := range c.Args {
+			c.Args[j] = translateEraserArg(c.Args[j])
+		}
+		for j := range c.Command {
+			c.Command[j] = translateEraserArg(c.Command[j])
+		}
 	}
 }
 
-// rewriteSharedDataMounts rewrites the shared-data emptyDir mount path from its
-// Linux form to the Windows form for a single container.
-func rewriteSharedDataMounts(c *corev1.Container) {
-	for i := range c.VolumeMounts {
-		if c.VolumeMounts[i].MountPath == eraserUtils.LinuxSharedDataPath {
-			c.VolumeMounts[i].MountPath = eraserUtils.WindowsSharedDataPath
-		}
+// linuxToWindowsEraserPath rewrites an absolute eraser.sh path (e.g. the
+// shared-data emptyDir mount or the imagelist configmap mount) from its Linux
+// form to the Windows form.
+func linuxToWindowsEraserPath(p string) string {
+	if strings.HasPrefix(p, eraserUtils.LinuxEraserPath) {
+		rest := strings.ReplaceAll(strings.TrimPrefix(p, eraserUtils.LinuxEraserPath), "/", `\`)
+		return eraserUtils.WindowsEraserPath + rest
 	}
+	return p
+}
+
+// translateEraserArg rewrites an eraser.sh path embedded in a container arg or
+// command entry (e.g. "--imagelist=/run/eraser.sh/imagelist/images").
+func translateEraserArg(a string) string {
+	idx := strings.Index(a, eraserUtils.LinuxEraserPath)
+	if idx < 0 {
+		return a
+	}
+	return a[:idx] + linuxToWindowsEraserPath(a[idx:])
 }

--- a/controllers/imagejob/imagejob_controller.go
+++ b/controllers/imagejob/imagejob_controller.go
@@ -619,6 +619,9 @@ func fillLinuxPodSpec(templateSpec *corev1.PodSpec, runtimeSpec *unversioned.Run
 // pod-level security context, and eraser.sh paths in mounts, args and commands
 // are rewritten to their Windows form.
 func fillWindowsPodSpec(templateSpec *corev1.PodSpec) {
+	// Declare the pod's OS so the apiserver enforces Windows OS-field
+	// consistency (e.g. rejects leftover Linux-only securityContext fields).
+	templateSpec.OS = &corev1.PodOS{Name: corev1.Windows}
 	templateSpec.HostNetwork = true
 	templateSpec.SecurityContext = eraserUtils.WindowsHostProcessPodSecurityContext()
 

--- a/controllers/imagejob/imagejob_controller.go
+++ b/controllers/imagejob/imagejob_controller.go
@@ -62,13 +62,6 @@ const (
 	runtimeSockVolumeName  = "runtime-sock-volume"
 	windowsSandboxMountEnv = "%CONTAINER_SANDBOX_MOUNT_POINT%"
 
-	// windowsMinMemoryLimit is the smallest memory limit a Windows HostProcess
-	// worker container is given. On Windows a memory limit is enforced job-wide
-	// via a Job Object, and a limit too small for the Go runtime to start
-	// (e.g. the remover's 30Mi Linux default) makes the process crash during
-	// startup with STATUS_STACK_OVERFLOW (0xC00000FD) before any code runs.
-	// 256Mi was verified to start reliably on Windows Server 2022 /
-	// containerd 1.7; 30Mi does not. Larger configured limits are left as-is.
 	windowsMinMemoryLimit = "256Mi"
 )
 
@@ -623,11 +616,7 @@ func fillLinuxPodSpec(templateSpec *corev1.PodSpec, runtimeSpec *unversioned.Run
 }
 
 // fillWindowsPodSpec turns the Linux-shaped template into a Windows HostProcess
-// pod. A HostProcess pod runs in the host network namespace and reaches the
-// containerd named pipe directly, so no CRI hostPath volume or mount is added.
-// The Linux-only container security context is dropped in favor of a HostProcess
-// pod-level security context, and eraser.sh paths in mounts, args and commands
-// are rewritten to their Windows form.
+// pod.
 func fillWindowsPodSpec(templateSpec *corev1.PodSpec) {
 	// Declare the pod's OS so the apiserver enforces Windows OS-field
 	// consistency (e.g. rejects leftover Linux-only securityContext fields).

--- a/controllers/imagejob/imagejob_controller.go
+++ b/controllers/imagejob/imagejob_controller.go
@@ -637,15 +637,7 @@ func fillWindowsPodSpec(templateSpec *corev1.PodSpec) {
 		// program").
 		c.Resources = corev1.ResourceRequirements{}
 
-		// A HostProcess container's binary lives under the ephemeral sandbox
-		// mount point, whose location is only known at runtime via the
-		// CONTAINER_SANDBOX_MOUNT_POINT environment variable. The kubelet
-		// expands that variable in the pod spec command (but not in a baked-in
-		// image ENTRYPOINT), so set an explicit command. Eraser's Windows worker
-		// images expose the binary as <container-name>.exe at the image root.
-		if len(c.Command) == 0 {
-			c.Command = []string{windowsSandboxMountEnv + `\` + c.Name + ".exe"}
-		}
+		c.Command = []string{windowsSandboxMountEnv + `\` + c.Name + ".exe"}
 
 		for j := range c.VolumeMounts {
 			c.VolumeMounts[j].MountPath = linuxToWindowsEraserPath(c.VolumeMounts[j].MountPath)

--- a/controllers/imagejob/imagejob_controller.go
+++ b/controllers/imagejob/imagejob_controller.go
@@ -56,6 +56,9 @@ const (
 	removerContainer     = "remover"
 	managerLabelValue    = "controller-manager"
 	managerLabelKey      = "control-plane"
+
+	windowsOS             = "windows"
+	runtimeSockVolumeName = "runtime-sock-volume"
 )
 
 var log = logf.Log.WithName("controller").WithValues("process", "imagejob-controller")
@@ -531,37 +534,21 @@ nodes:
 }
 
 func copyAndFillTemplateSpec(templateSpecTemplate *corev1.PodSpec, env []corev1.EnvVar, node *corev1.Node, runtimeSpec *unversioned.RuntimeSpec) (*corev1.PodSpec, error) {
-	nodeName := node.Name
-
-	u, err := url.Parse(runtimeSpec.Address)
-	if err != nil {
-		return nil, err
-	}
-
-	volumes := []corev1.Volume{
-		{Name: "runtime-sock-volume", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: u.Path}}},
-	}
-
-	volumeMounts := []corev1.VolumeMount{
-		{MountPath: controllerUtils.CRIPath, Name: "runtime-sock-volume"},
-	}
-
 	templateSpec := templateSpecTemplate.DeepCopy()
 	templateSpec.Tolerations = defaultTolerations
+	templateSpec.NodeName = node.Name
 
+	// Environment injection is OS-independent.
 	eraserImg := &templateSpec.Containers[0]
-	eraserImg.VolumeMounts = append(eraserImg.VolumeMounts, volumeMounts...)
 	eraserImg.Env = append(eraserImg.Env, env...)
 
 	if len(templateSpec.Containers) > 1 {
 		collectorImg := &templateSpec.Containers[1]
-		collectorImg.VolumeMounts = append(collectorImg.VolumeMounts, volumeMounts...)
 		collectorImg.Env = append(collectorImg.Env, env...)
 	}
 
 	if len(templateSpec.Containers) > 2 {
 		scannerImg := &templateSpec.Containers[2]
-		scannerImg.VolumeMounts = append(scannerImg.VolumeMounts, volumeMounts...)
 		scannerImg.Env = append(scannerImg.Env,
 			corev1.EnvVar{
 				Name:  controllerUtils.EnvVarContainerdNamespaceKey,
@@ -578,8 +565,77 @@ func copyAndFillTemplateSpec(templateSpecTemplate *corev1.PodSpec, env []corev1.
 		}
 	}
 
-	templateSpec.Volumes = append(volumes, templateSpec.Volumes...)
-	templateSpec.NodeName = nodeName
+	if isWindowsNode(node) {
+		fillWindowsPodSpec(templateSpec)
+		return templateSpec, nil
+	}
+
+	if err := fillLinuxPodSpec(templateSpec, runtimeSpec); err != nil {
+		return nil, err
+	}
 
 	return templateSpec, nil
+}
+
+// isWindowsNode reports whether the node runs Windows, preferring the
+// kubernetes.io/os label and falling back to the reported node OS.
+func isWindowsNode(node *corev1.Node) bool {
+	if osName, ok := node.Labels[corev1.LabelOSStable]; ok {
+		return strings.EqualFold(osName, windowsOS)
+	}
+	return strings.EqualFold(node.Status.NodeInfo.OperatingSystem, windowsOS)
+}
+
+// fillLinuxPodSpec mounts the host CRI socket into every worker container via a
+// hostPath volume.
+func fillLinuxPodSpec(templateSpec *corev1.PodSpec, runtimeSpec *unversioned.RuntimeSpec) error {
+	u, err := url.Parse(runtimeSpec.Address)
+	if err != nil {
+		return err
+	}
+
+	volumes := []corev1.Volume{
+		{Name: runtimeSockVolumeName, VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: u.Path}}},
+	}
+
+	volumeMounts := []corev1.VolumeMount{
+		{MountPath: controllerUtils.CRIPath, Name: runtimeSockVolumeName},
+	}
+
+	for i := range templateSpec.Containers {
+		templateSpec.Containers[i].VolumeMounts = append(templateSpec.Containers[i].VolumeMounts, volumeMounts...)
+	}
+
+	templateSpec.Volumes = append(volumes, templateSpec.Volumes...)
+
+	return nil
+}
+
+// fillWindowsPodSpec turns the Linux-shaped template into a Windows HostProcess
+// pod. A HostProcess pod runs in the host network namespace and reaches the
+// containerd named pipe directly, so no CRI hostPath volume or mount is added.
+// The Linux-only container security context is dropped in favor of a HostProcess
+// pod-level security context, and shared-data mount paths are rewritten to their
+// Windows form.
+func fillWindowsPodSpec(templateSpec *corev1.PodSpec) {
+	templateSpec.HostNetwork = true
+	templateSpec.SecurityContext = eraserUtils.WindowsHostProcessPodSecurityContext()
+
+	for i := range templateSpec.Containers {
+		c := &templateSpec.Containers[i]
+		// SharedSecurityContext sets Linux-only fields (capabilities,
+		// seccompProfile, readOnlyRootFilesystem) that are invalid on Windows.
+		c.SecurityContext = nil
+		rewriteSharedDataMounts(c)
+	}
+}
+
+// rewriteSharedDataMounts rewrites the shared-data emptyDir mount path from its
+// Linux form to the Windows form for a single container.
+func rewriteSharedDataMounts(c *corev1.Container) {
+	for i := range c.VolumeMounts {
+		if c.VolumeMounts[i].MountPath == eraserUtils.LinuxSharedDataPath {
+			c.VolumeMounts[i].MountPath = eraserUtils.WindowsSharedDataPath
+		}
+	}
 }

--- a/controllers/imagejob/imagejob_controller.go
+++ b/controllers/imagejob/imagejob_controller.go
@@ -570,7 +570,7 @@ func copyAndFillTemplateSpec(templateSpecTemplate *corev1.PodSpec, env []corev1.
 	}
 
 	if isWindowsNode(node) {
-		fillWindowsPodSpec(templateSpec)
+		fillWindowsPodSpec(templateSpec, runtimeSpec)
 		return templateSpec, nil
 	}
 
@@ -617,18 +617,30 @@ func fillLinuxPodSpec(templateSpec *corev1.PodSpec, runtimeSpec *unversioned.Run
 
 // fillWindowsPodSpec turns the Linux-shaped template into a Windows HostProcess
 // pod.
-func fillWindowsPodSpec(templateSpec *corev1.PodSpec) {
+func fillWindowsPodSpec(templateSpec *corev1.PodSpec, runtimeSpec *unversioned.RuntimeSpec) {
 	// Declare the pod's OS so the apiserver enforces Windows OS-field
 	// consistency (e.g. rejects leftover Linux-only securityContext fields).
 	templateSpec.OS = &corev1.PodOS{Name: corev1.Windows}
 	templateSpec.HostNetwork = true
 	templateSpec.SecurityContext = eraserUtils.WindowsHostProcessPodSecurityContext()
 
+	// A Windows named pipe cannot be hostPath-mounted like a Linux socket, so
+	// the CRI endpoint is propagated to workers via an environment variable.
+	var runtimeAddressEnv []corev1.EnvVar
+	if runtimeSpec != nil && runtimeSpec.WindowsAddress != "" {
+		runtimeAddressEnv = []corev1.EnvVar{{
+			Name:  eraserUtils.EnvEraserRuntimeAddress,
+			Value: runtimeSpec.WindowsAddress,
+		}}
+	}
+
 	for i := range templateSpec.Containers {
 		c := &templateSpec.Containers[i]
 		// SharedSecurityContext sets Linux-only fields (capabilities,
 		// seccompProfile, readOnlyRootFilesystem) that are invalid on Windows.
 		c.SecurityContext = nil
+
+		c.Env = append(c.Env, runtimeAddressEnv...)
 
 		// A Windows memory limit is enforced job-wide via a Job Object. A limit
 		// too small for the Go runtime to start crashes the container before any

--- a/controllers/imagejob/imagejob_controller.go
+++ b/controllers/imagejob/imagejob_controller.go
@@ -23,6 +23,7 @@ import (
 
 	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -60,6 +61,15 @@ const (
 	windowsOS              = "windows"
 	runtimeSockVolumeName  = "runtime-sock-volume"
 	windowsSandboxMountEnv = "%CONTAINER_SANDBOX_MOUNT_POINT%"
+
+	// windowsMinMemoryLimit is the smallest memory limit a Windows HostProcess
+	// worker container is given. On Windows a memory limit is enforced job-wide
+	// via a Job Object, and a limit too small for the Go runtime to start
+	// (e.g. the remover's 30Mi Linux default) makes the process crash during
+	// startup with STATUS_STACK_OVERFLOW (0xC00000FD) before any code runs.
+	// 256Mi was verified to start reliably on Windows Server 2022 /
+	// containerd 1.7; 30Mi does not. Larger configured limits are left as-is.
+	windowsMinMemoryLimit = "256Mi"
 )
 
 var log = logf.Log.WithName("controller").WithValues("process", "imagejob-controller")
@@ -631,11 +641,11 @@ func fillWindowsPodSpec(templateSpec *corev1.PodSpec) {
 		// seccompProfile, readOnlyRootFilesystem) that are invalid on Windows.
 		c.SecurityContext = nil
 
-		// Windows HostProcess containers run directly on the host and do not
-		// support CPU/memory requests or limits; leaving them set makes the
-		// container fail to start ("The system cannot execute the specified
-		// program").
-		c.Resources = corev1.ResourceRequirements{}
+		// A Windows memory limit is enforced job-wide via a Job Object. A limit
+		// too small for the Go runtime to start crashes the container before any
+		// code runs (STATUS_STACK_OVERFLOW). Raise an existing memory limit that
+		// is below the verified-safe minimum; leave an unset limit untouched.
+		raiseWindowsMemoryLimit(c)
 
 		c.Command = []string{windowsSandboxMountEnv + `\` + c.Name + ".exe"}
 
@@ -645,6 +655,20 @@ func fillWindowsPodSpec(templateSpec *corev1.PodSpec) {
 		for j := range c.Args {
 			c.Args[j] = translateEraserArg(c.Args[j])
 		}
+	}
+}
+
+// raiseWindowsMemoryLimit bumps a container's memory limit up to the
+// Windows-safe minimum when a smaller limit is configured. A limit that is not
+// set is left unset (no Job Object memory cap, so no startup crash).
+func raiseWindowsMemoryLimit(c *corev1.Container) {
+	limit, ok := c.Resources.Limits[corev1.ResourceMemory]
+	if !ok {
+		return
+	}
+	minLimit := resource.MustParse(windowsMinMemoryLimit)
+	if limit.Cmp(minLimit) < 0 {
+		c.Resources.Limits[corev1.ResourceMemory] = minLimit
 	}
 }
 

--- a/controllers/imagejob/imagejob_controller.go
+++ b/controllers/imagejob/imagejob_controller.go
@@ -645,9 +645,6 @@ func fillWindowsPodSpec(templateSpec *corev1.PodSpec) {
 		for j := range c.Args {
 			c.Args[j] = translateEraserArg(c.Args[j])
 		}
-		for j := range c.Command {
-			c.Command[j] = translateEraserArg(c.Command[j])
-		}
 	}
 }
 

--- a/controllers/imagejob/imagejob_controller.go
+++ b/controllers/imagejob/imagejob_controller.go
@@ -649,10 +649,12 @@ func fillWindowsPodSpec(templateSpec *corev1.PodSpec) {
 
 // raiseWindowsMemoryLimit bumps a container's memory limit up to the
 // Windows-safe minimum when a smaller limit is configured. A limit that is not
-// set is left unset (no Job Object memory cap, so no startup crash).
+// set or is explicitly zero is left as-is (no Job Object memory cap).
 func raiseWindowsMemoryLimit(c *corev1.Container) {
 	limit, ok := c.Resources.Limits[corev1.ResourceMemory]
-	if !ok {
+	// An unset or explicit zero limit means no Job Object memory cap, so there
+	// is no startup crash to guard against; leave it as-is.
+	if !ok || limit.IsZero() {
 		return
 	}
 	minLimit := resource.MustParse(windowsMinMemoryLimit)

--- a/controllers/imagejob/imagejob_controller_test.go
+++ b/controllers/imagejob/imagejob_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/eraser-dev/eraser/api/unversioned"
@@ -23,14 +24,20 @@ func newTemplateSpec() *corev1.PodSpec {
 		Containers: []corev1.Container{
 			{
 				Name: "collector",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("25Mi")},
+					Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("30Mi")},
+				},
 				VolumeMounts: []corev1.VolumeMount{
 					{MountPath: sharedDataMountPath, Name: "shared-data"},
 				},
 			},
 			{
 				Name: removerContainer,
+				Args: []string{"--imagelist=/run/eraser.sh/imagelist/images", "--log-level=info"},
 				VolumeMounts: []corev1.VolumeMount{
 					{MountPath: sharedDataMountPath, Name: "shared-data"},
+					{MountPath: "/run/eraser.sh/imagelist", Name: "imagelist"},
 				},
 				SecurityContext: eraserUtils.SharedSecurityContext,
 			},
@@ -141,6 +148,26 @@ func TestCopyAndFillTemplateSpecWindows(t *testing.T) {
 		if c.SecurityContext != nil {
 			t.Errorf("container %q Linux SecurityContext should be cleared on Windows", c.Name)
 		}
+		if len(c.Resources.Requests) != 0 || len(c.Resources.Limits) != 0 {
+			t.Errorf("container %q resources should be cleared on Windows HostProcess", c.Name)
+		}
+	}
+
+	// The remover's imagelist mount and --imagelist arg must be rewritten to Windows paths.
+	rem := &spec.Containers[1]
+	if p, _ := containerMountPath(rem, "imagelist"); p != `C:\run\eraser.sh\imagelist` {
+		t.Errorf("imagelist mount = %q, want C:\\run\\eraser.sh\\imagelist", p)
+	}
+	if rem.Args[0] != `--imagelist=C:\run\eraser.sh\imagelist\images` {
+		t.Errorf("imagelist arg = %q, want windows form", rem.Args[0])
+	}
+	if rem.Args[1] != "--log-level=info" {
+		t.Errorf("non-path arg should be untouched, got %q", rem.Args[1])
+	}
+	// HostProcess containers need an explicit sandbox-relative command.
+	wantCmd := `%CONTAINER_SANDBOX_MOUNT_POINT%\remover.exe`
+	if len(rem.Command) != 1 || rem.Command[0] != wantCmd {
+		t.Errorf("remover command = %v, want [%s]", rem.Command, wantCmd)
 	}
 }
 

--- a/controllers/imagejob/imagejob_controller_test.go
+++ b/controllers/imagejob/imagejob_controller_test.go
@@ -19,7 +19,7 @@ const sharedDataMountPath = eraserUtils.LinuxSharedDataPath
 func newTemplateSpec() *corev1.PodSpec {
 	return &corev1.PodSpec{
 		Volumes: []corev1.Volume{
-			{Name: "shared-data"},
+			{Name: "shared-data", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 		},
 		Containers: []corev1.Container{
 			{

--- a/controllers/imagejob/imagejob_controller_test.go
+++ b/controllers/imagejob/imagejob_controller_test.go
@@ -154,9 +154,23 @@ func TestCopyAndFillTemplateSpecWindows(t *testing.T) {
 		if c.SecurityContext != nil {
 			t.Errorf("container %q Linux SecurityContext should be cleared on Windows", c.Name)
 		}
-		if len(c.Resources.Requests) != 0 || len(c.Resources.Limits) != 0 {
-			t.Errorf("container %q resources should be cleared on Windows HostProcess", c.Name)
-		}
+	}
+
+	// collector had a 30Mi memory limit (< 256Mi) -> raised to 256Mi; its 25Mi
+	// request is preserved.
+	col := &spec.Containers[0]
+	wantMin := resource.MustParse("256Mi")
+	if got := col.Resources.Limits[corev1.ResourceMemory]; got.Cmp(wantMin) != 0 {
+		t.Errorf("collector memory limit = %s, want 256Mi", got.String())
+	}
+	if got := col.Resources.Requests[corev1.ResourceMemory]; got.Cmp(resource.MustParse("25Mi")) != 0 {
+		t.Errorf("collector memory request = %s, want 25Mi (unchanged)", got.String())
+	}
+
+	// remover had no memory limit -> left unset (no Job Object memory cap).
+	rmv := &spec.Containers[1]
+	if _, ok := rmv.Resources.Limits[corev1.ResourceMemory]; ok {
+		t.Error("remover had no memory limit; it should stay unset on Windows")
 	}
 
 	// The remover's imagelist mount and --imagelist arg must be rewritten to Windows paths.
@@ -176,6 +190,40 @@ func TestCopyAndFillTemplateSpecWindows(t *testing.T) {
 		t.Errorf("remover command = %v, want [%s]", rem.Command, wantCmd)
 	}
 }
+
+func TestRaiseWindowsMemoryLimit(t *testing.T) {
+	cases := []struct {
+		name  string
+		limit *string // nil = unset
+		want  *string // nil = still unset
+	}{
+		{"below min is raised", ptr("30Mi"), ptr("256Mi")},
+		{"at min is unchanged", ptr("256Mi"), ptr("256Mi")},
+		{"above min is unchanged", ptr("512Mi"), ptr("512Mi")},
+		{"unset stays unset", nil, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &corev1.Container{}
+			if tc.limit != nil {
+				c.Resources.Limits = corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(*tc.limit)}
+			}
+			raiseWindowsMemoryLimit(c)
+			got, ok := c.Resources.Limits[corev1.ResourceMemory]
+			if tc.want == nil {
+				if ok {
+					t.Errorf("memory limit = %s, want unset", got.String())
+				}
+				return
+			}
+			if !ok || got.Cmp(resource.MustParse(*tc.want)) != 0 {
+				t.Errorf("memory limit = %v, want %s", got, *tc.want)
+			}
+		})
+	}
+}
+
+func ptr(s string) *string { return &s }
 
 func TestIsWindowsNode(t *testing.T) {
 	cases := []struct {

--- a/controllers/imagejob/imagejob_controller_test.go
+++ b/controllers/imagejob/imagejob_controller_test.go
@@ -55,8 +55,9 @@ func node(name, osLabel string) *corev1.Node {
 
 func runtimeSpec() *unversioned.RuntimeSpec {
 	return &unversioned.RuntimeSpec{
-		Name:    unversioned.RuntimeContainerd,
-		Address: "unix:///run/containerd/containerd.sock",
+		Name:           unversioned.RuntimeContainerd,
+		Address:        "unix:///run/containerd/containerd.sock",
+		WindowsAddress: "npipe://./pipe/custom-containerd",
 	}
 }
 
@@ -73,6 +74,15 @@ func containerMountPath(c *corev1.Container, volumeName string) (string, bool) {
 	for i := range c.VolumeMounts {
 		if c.VolumeMounts[i].Name == volumeName {
 			return c.VolumeMounts[i].MountPath, true
+		}
+	}
+	return "", false
+}
+
+func containerEnv(c *corev1.Container, name string) (string, bool) {
+	for i := range c.Env {
+		if c.Env[i].Name == name {
+			return c.Env[i].Value, true
 		}
 	}
 	return "", false
@@ -154,6 +164,11 @@ func TestCopyAndFillTemplateSpecWindows(t *testing.T) {
 		if c.SecurityContext != nil {
 			t.Errorf("container %q Linux SecurityContext should be cleared on Windows", c.Name)
 		}
+		// The configured Windows runtime address is propagated to every worker
+		// via an env var (a named pipe cannot be hostPath-mounted).
+		if got, ok := containerEnv(c, eraserUtils.EnvEraserRuntimeAddress); !ok || got != "npipe://./pipe/custom-containerd" {
+			t.Errorf("container %q %s env = %q (present=%v), want npipe://./pipe/custom-containerd", c.Name, eraserUtils.EnvEraserRuntimeAddress, got, ok)
+		}
 	}
 
 	// collector had a 30Mi memory limit (< 256Mi) -> raised to 256Mi; its 25Mi
@@ -188,6 +203,22 @@ func TestCopyAndFillTemplateSpecWindows(t *testing.T) {
 	wantCmd := `%CONTAINER_SANDBOX_MOUNT_POINT%\remover.exe`
 	if len(rem.Command) != 1 || rem.Command[0] != wantCmd {
 		t.Errorf("remover command = %v, want [%s]", rem.Command, wantCmd)
+	}
+}
+
+// When no Windows runtime address is configured, no env override is injected;
+// the worker falls back to its default containerd pipe.
+func TestCopyAndFillTemplateSpecWindowsNoRuntimeAddress(t *testing.T) {
+	rs := &unversioned.RuntimeSpec{Name: unversioned.RuntimeContainerd, Address: "unix:///run/containerd/containerd.sock"}
+	spec, err := copyAndFillTemplateSpec(newTemplateSpec(), nil, node("win-node", "windows"), rs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i := range spec.Containers {
+		c := &spec.Containers[i]
+		if v, ok := containerEnv(c, eraserUtils.EnvEraserRuntimeAddress); ok {
+			t.Errorf("container %q should not have %s env when unset, got %q", c.Name, eraserUtils.EnvEraserRuntimeAddress, v)
+		}
 	}
 }
 

--- a/controllers/imagejob/imagejob_controller_test.go
+++ b/controllers/imagejob/imagejob_controller_test.go
@@ -90,6 +90,9 @@ func TestCopyAndFillTemplateSpecLinux(t *testing.T) {
 	if spec.HostNetwork {
 		t.Error("HostNetwork should be false for a Linux node")
 	}
+	if spec.OS != nil {
+		t.Errorf("spec.OS should be unset on a Linux node, got %v", spec.OS)
+	}
 	if !hasVolume(spec, runtimeSockVolumeName) {
 		t.Errorf("expected CRI hostPath volume %q on a Linux node", runtimeSockVolumeName)
 	}
@@ -121,6 +124,9 @@ func TestCopyAndFillTemplateSpecWindows(t *testing.T) {
 	}
 	if !spec.HostNetwork {
 		t.Error("HostNetwork should be true for a Windows HostProcess pod")
+	}
+	if spec.OS == nil || spec.OS.Name != corev1.Windows {
+		t.Errorf("spec.OS = %v, want Name=windows", spec.OS)
 	}
 	if hasVolume(spec, runtimeSockVolumeName) {
 		t.Error("CRI hostPath volume must be omitted on a Windows node")

--- a/controllers/imagejob/imagejob_controller_test.go
+++ b/controllers/imagejob/imagejob_controller_test.go
@@ -200,6 +200,7 @@ func TestRaiseWindowsMemoryLimit(t *testing.T) {
 		{"below min is raised", ptr("30Mi"), ptr("256Mi")},
 		{"at min is unchanged", ptr("256Mi"), ptr("256Mi")},
 		{"above min is unchanged", ptr("512Mi"), ptr("512Mi")},
+		{"explicit zero stays unlimited", ptr("0"), ptr("0")},
 		{"unset stays unset", nil, nil},
 	}
 	for _, tc := range cases {

--- a/controllers/imagejob/imagejob_controller_test.go
+++ b/controllers/imagejob/imagejob_controller_test.go
@@ -1,0 +1,167 @@
+package imagejob
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/eraser-dev/eraser/api/unversioned"
+	controllerUtils "github.com/eraser-dev/eraser/controllers/util"
+	eraserUtils "github.com/eraser-dev/eraser/pkg/utils"
+)
+
+// sharedDataMountPath mirrors the Linux path the collector controller bakes into
+// the pod template before the manager fills it per node.
+const sharedDataMountPath = eraserUtils.LinuxSharedDataPath
+
+func newTemplateSpec() *corev1.PodSpec {
+	return &corev1.PodSpec{
+		Volumes: []corev1.Volume{
+			{Name: "shared-data"},
+		},
+		Containers: []corev1.Container{
+			{
+				Name: "collector",
+				VolumeMounts: []corev1.VolumeMount{
+					{MountPath: sharedDataMountPath, Name: "shared-data"},
+				},
+			},
+			{
+				Name: removerContainer,
+				VolumeMounts: []corev1.VolumeMount{
+					{MountPath: sharedDataMountPath, Name: "shared-data"},
+				},
+				SecurityContext: eraserUtils.SharedSecurityContext,
+			},
+		},
+	}
+}
+
+func node(name, osLabel string) *corev1.Node {
+	n := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	if osLabel != "" {
+		n.Labels = map[string]string{corev1.LabelOSStable: osLabel}
+	}
+	return n
+}
+
+func runtimeSpec() *unversioned.RuntimeSpec {
+	return &unversioned.RuntimeSpec{
+		Name:    unversioned.RuntimeContainerd,
+		Address: "unix:///run/containerd/containerd.sock",
+	}
+}
+
+func hasVolume(spec *corev1.PodSpec, name string) bool {
+	for i := range spec.Volumes {
+		if spec.Volumes[i].Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func containerMountPath(c *corev1.Container, volumeName string) (string, bool) {
+	for i := range c.VolumeMounts {
+		if c.VolumeMounts[i].Name == volumeName {
+			return c.VolumeMounts[i].MountPath, true
+		}
+	}
+	return "", false
+}
+
+func TestCopyAndFillTemplateSpecLinux(t *testing.T) {
+	spec, err := copyAndFillTemplateSpec(newTemplateSpec(), nil, node("linux-node", "linux"), runtimeSpec())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if spec.NodeName != "linux-node" {
+		t.Errorf("NodeName = %q, want linux-node", spec.NodeName)
+	}
+	if spec.HostNetwork {
+		t.Error("HostNetwork should be false for a Linux node")
+	}
+	if !hasVolume(spec, runtimeSockVolumeName) {
+		t.Errorf("expected CRI hostPath volume %q on a Linux node", runtimeSockVolumeName)
+	}
+	for i := range spec.Containers {
+		if p, ok := containerMountPath(&spec.Containers[i], runtimeSockVolumeName); !ok {
+			t.Errorf("container %q missing CRI mount", spec.Containers[i].Name)
+		} else if p != controllerUtils.CRIPath {
+			t.Errorf("CRI mount path = %q, want %q", p, controllerUtils.CRIPath)
+		}
+		if p, _ := containerMountPath(&spec.Containers[i], "shared-data"); p != eraserUtils.LinuxSharedDataPath {
+			t.Errorf("shared-data mount = %q, want Linux path %q", p, eraserUtils.LinuxSharedDataPath)
+		}
+	}
+	// Linux security context is preserved on the remover container.
+	sc := spec.Containers[1].SecurityContext
+	if sc == nil || sc.ReadOnlyRootFilesystem == nil || !*sc.ReadOnlyRootFilesystem {
+		t.Error("expected Linux SharedSecurityContext preserved on Linux node")
+	}
+}
+
+func TestCopyAndFillTemplateSpecWindows(t *testing.T) {
+	spec, err := copyAndFillTemplateSpec(newTemplateSpec(), nil, node("win-node", "windows"), runtimeSpec())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if spec.NodeName != "win-node" {
+		t.Errorf("NodeName = %q, want win-node", spec.NodeName)
+	}
+	if !spec.HostNetwork {
+		t.Error("HostNetwork should be true for a Windows HostProcess pod")
+	}
+	if hasVolume(spec, runtimeSockVolumeName) {
+		t.Error("CRI hostPath volume must be omitted on a Windows node")
+	}
+
+	if spec.SecurityContext == nil || spec.SecurityContext.WindowsOptions == nil {
+		t.Fatal("expected pod-level Windows HostProcess security context")
+	}
+	wo := spec.SecurityContext.WindowsOptions
+	if wo.HostProcess == nil || !*wo.HostProcess {
+		t.Error("HostProcess should be true")
+	}
+	if wo.RunAsUserName == nil || *wo.RunAsUserName != eraserUtils.WindowsHostProcessUserName {
+		t.Errorf("RunAsUserName = %v, want %q", wo.RunAsUserName, eraserUtils.WindowsHostProcessUserName)
+	}
+
+	for i := range spec.Containers {
+		c := &spec.Containers[i]
+		if _, ok := containerMountPath(c, runtimeSockVolumeName); ok {
+			t.Errorf("container %q should not have a CRI mount on Windows", c.Name)
+		}
+		if p, _ := containerMountPath(c, "shared-data"); p != eraserUtils.WindowsSharedDataPath {
+			t.Errorf("shared-data mount = %q, want Windows path %q", p, eraserUtils.WindowsSharedDataPath)
+		}
+		if c.SecurityContext != nil {
+			t.Errorf("container %q Linux SecurityContext should be cleared on Windows", c.Name)
+		}
+	}
+}
+
+func TestIsWindowsNode(t *testing.T) {
+	cases := []struct {
+		name string
+		node *corev1.Node
+		want bool
+	}{
+		{"label windows", node("a", "windows"), true},
+		{"label linux", node("b", "linux"), false},
+		{"no label falls back to nodeinfo", &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "c"},
+			Status:     corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{OperatingSystem: "windows"}},
+		}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isWindowsNode(tc.node); got != tc.want {
+				t.Errorf("isWindowsNode = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/controllers/imagejob/imagejob_windows_validation_test.go
+++ b/controllers/imagejob/imagejob_windows_validation_test.go
@@ -1,0 +1,133 @@
+package imagejob
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+// startEnvtest brings up a real kube-apiserver + etcd so that emitted pod specs
+// can be checked against the apiserver's own validation (dry-run create). It is
+// skipped when the envtest binaries are not available (KUBEBUILDER_ASSETS unset),
+// so `go test` still works without them; `make test` sets that variable.
+func startEnvtest(t *testing.T) (client.Client, func()) {
+	t.Helper()
+
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		t.Skip("KUBEBUILDER_ASSETS not set; skipping apiserver validation test (run via `make test`)")
+	}
+
+	testEnv := &envtest.Environment{}
+	cfg, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("failed to start envtest: %v", err)
+	}
+
+	cl, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		_ = testEnv.Stop()
+		t.Fatalf("failed to build client: %v", err)
+	}
+
+	return cl, func() { _ = testEnv.Stop() }
+}
+
+func windowsPod(spec *corev1.PodSpec) *corev1.Pod {
+	// NodeName is set by the manager, but a dry-run create against the apiserver
+	// should validate the spec without a real node; clear it to avoid binding.
+	s := spec.DeepCopy()
+	s.NodeName = ""
+
+	// Fill fields the manager does not touch but the apiserver requires, so the
+	// test exercises OS validation rather than unrelated required-field errors.
+	backed := map[string]bool{}
+	for i := range s.Volumes {
+		backed[s.Volumes[i].Name] = true
+	}
+	for i := range s.Containers {
+		if s.Containers[i].Image == "" {
+			s.Containers[i].Image = "example.invalid/image:latest"
+		}
+		for _, vm := range s.Containers[i].VolumeMounts {
+			if vm.Name == "" || backed[vm.Name] {
+				continue
+			}
+			s.Volumes = append(s.Volumes, corev1.Volume{
+				Name:         vm.Name,
+				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+			})
+			backed[vm.Name] = true
+		}
+	}
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "eraser-win-validate-",
+			Namespace:    "default",
+		},
+		Spec: *s,
+	}
+}
+
+// TestWindowsPodSpecPassesAPIServerValidation is a guardrail: the Windows pod
+// spec the manager emits must be accepted by the Kubernetes apiserver. Because
+// the spec declares spec.os.name=windows, the apiserver runs validateOSFields,
+// which rejects Linux-only fields. If a future change adds a Windows-unsupported
+// field to the emitted spec, this test fails at admission rather than the break
+// only surfacing on a live Windows node.
+func TestWindowsPodSpecPassesAPIServerValidation(t *testing.T) {
+	cl, stop := startEnvtest(t)
+	defer stop()
+
+	spec, err := copyAndFillTemplateSpec(newTemplateSpec(), nil, node("win-node", "windows"), runtimeSpec())
+	if err != nil {
+		t.Fatalf("copyAndFillTemplateSpec: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pod := windowsPod(spec)
+	if err := cl.Create(ctx, pod, client.DryRunAll); err != nil {
+		t.Fatalf("apiserver rejected the emitted Windows pod spec: %v", err)
+	}
+}
+
+// TestWindowsPodSpecRejectsLinuxOnlyField proves the guardrail has teeth: a
+// Windows pod carrying a Linux-only container field (capabilities, exactly what
+// SharedSecurityContext sets) must be rejected by the apiserver. This is what
+// catches a regression where someone forgets to clear a Linux-only field on the
+// Windows path.
+func TestWindowsPodSpecRejectsLinuxOnlyField(t *testing.T) {
+	cl, stop := startEnvtest(t)
+	defer stop()
+
+	spec, err := copyAndFillTemplateSpec(newTemplateSpec(), nil, node("win-node", "windows"), runtimeSpec())
+	if err != nil {
+		t.Fatalf("copyAndFillTemplateSpec: %v", err)
+	}
+
+	// Re-introduce a Linux-only field on a container, simulating a regression.
+	spec.Containers[0].SecurityContext = &corev1.SecurityContext{
+		Capabilities: &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err = cl.Create(ctx, windowsPod(spec), client.DryRunAll)
+	if err == nil {
+		t.Fatal("expected apiserver to reject a Windows pod with a Linux-only capabilities field, but it was accepted")
+	}
+	if !apierrors.IsInvalid(err) {
+		t.Fatalf("expected an Invalid validation error, got: %v", err)
+	}
+}

--- a/pkg/utils/platform_windows.go
+++ b/pkg/utils/platform_windows.go
@@ -6,13 +6,27 @@ import (
 	"context"
 	"errors"
 	"net"
+	"os"
 
 	"github.com/Microsoft/go-winio"
 )
 
-// CRIPath is containerd's named pipe. Unlike Linux there is no socket to mount;
-// a HostProcess pod reaches the pipe directly.
-const CRIPath = `npipe://./pipe/containerd-containerd`
+// defaultCRIPath is containerd's named pipe. Unlike Linux there is no socket to
+// mount; a HostProcess pod reaches the pipe directly.
+const defaultCRIPath = `npipe://./pipe/containerd-containerd`
+
+// CRIPath is the CRI endpoint a Windows worker connects to. The manager
+// propagates a configurable address via EnvEraserRuntimeAddress (a Windows
+// named pipe cannot be hostPath-mounted like a Linux socket); when the env var
+// is unset the default containerd pipe is used.
+var CRIPath = resolveCRIPath()
+
+func resolveCRIPath() string {
+	if addr := os.Getenv(EnvEraserRuntimeAddress); addr != "" {
+		return addr
+	}
+	return defaultCRIPath
+}
 
 const defaultProtocol = npipeProtocol
 

--- a/pkg/utils/platform_windows_test.go
+++ b/pkg/utils/platform_windows_test.go
@@ -79,6 +79,19 @@ func TestSocketPathLimitBoundary(t *testing.T) {
 	}
 }
 
+func TestResolveCRIPath(t *testing.T) {
+	t.Setenv(EnvEraserRuntimeAddress, "")
+	if got := resolveCRIPath(); got != defaultCRIPath {
+		t.Errorf("resolveCRIPath() with unset env = %q, want default %q", got, defaultCRIPath)
+	}
+
+	custom := "npipe://./pipe/custom-containerd"
+	t.Setenv(EnvEraserRuntimeAddress, custom)
+	if got := resolveCRIPath(); got != custom {
+		t.Errorf("resolveCRIPath() = %q, want %q", got, custom)
+	}
+}
+
 func TestMkfifoUnsupported(t *testing.T) {
 	if err := mkfifo("ignored", PipeMode); !errors.Is(err, ErrFifoUnsupported) {
 		t.Errorf("mkfifo on windows = %v, want ErrFifoUnsupported", err)

--- a/pkg/utils/security_context.go
+++ b/pkg/utils/security_context.go
@@ -15,3 +15,23 @@ var SharedSecurityContext = &corev1.SecurityContext{
 		Type: corev1.SeccompProfileTypeRuntimeDefault,
 	},
 }
+
+// WindowsHostProcessUserName is the built-in account HostProcess worker pods run
+// as so they can reach the containerd named pipe on a Windows node.
+const WindowsHostProcessUserName = `NT AUTHORITY\SYSTEM`
+
+// WindowsHostProcessPodSecurityContext returns the pod-level security context
+// for a Windows worker pod. It runs the pod as a HostProcess pod under
+// NT AUTHORITY\SYSTEM. This is the Windows-safe replacement for the Linux-only
+// SharedSecurityContext, whose capabilities, seccompProfile and
+// readOnlyRootFilesystem fields are not valid on Windows.
+func WindowsHostProcessPodSecurityContext() *corev1.PodSecurityContext {
+	hostProcess := true
+	userName := WindowsHostProcessUserName
+	return &corev1.PodSecurityContext{
+		WindowsOptions: &corev1.WindowsSecurityContextOptions{
+			HostProcess:   &hostProcess,
+			RunAsUserName: &userName,
+		},
+	}
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -24,19 +24,9 @@ const (
 	npipeProtocol = "npipe"
 	PipeMode      = 0o644
 
-	// LinuxEraserPath and WindowsEraserPath are the base directory the eraser
-	// worker containers use for IPC/shared state. The manager always runs on
-	// Linux but emits pod specs for both Linux and Windows nodes, so it needs
-	// both values as plain (non build-tagged) constants to translate paths in
-	// mounts and args when emitting a Windows pod.
 	LinuxEraserPath   = "/run/eraser.sh"
 	WindowsEraserPath = `C:\run\eraser.sh`
 
-	// LinuxSharedDataPath and WindowsSharedDataPath are the in-container mount
-	// points of the shared-data emptyDir the worker containers use to exchange
-	// scan/erase results. These must stay in sync with the paths the worker
-	// binaries open (see the *Path constants below and their Windows
-	// equivalents used by the worker on Windows nodes).
 	LinuxSharedDataPath   = LinuxEraserPath + "/shared-data"
 	WindowsSharedDataPath = WindowsEraserPath + `\shared-data`
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -24,16 +24,21 @@ const (
 	npipeProtocol = "npipe"
 	PipeMode      = 0o644
 
+	// LinuxEraserPath and WindowsEraserPath are the base directory the eraser
+	// worker containers use for IPC/shared state. The manager always runs on
+	// Linux but emits pod specs for both Linux and Windows nodes, so it needs
+	// both values as plain (non build-tagged) constants to translate paths in
+	// mounts and args when emitting a Windows pod.
+	LinuxEraserPath   = "/run/eraser.sh"
+	WindowsEraserPath = `C:\run\eraser.sh`
+
 	// LinuxSharedDataPath and WindowsSharedDataPath are the in-container mount
 	// points of the shared-data emptyDir the worker containers use to exchange
-	// scan/erase results. The manager always runs on Linux but emits pod specs
-	// for both Linux and Windows nodes, so it needs both values as plain
-	// (non build-tagged) constants; a build-tagged constant would only expose
-	// the Linux value to the manager. These must stay in sync with the paths
-	// the worker binaries open (see the *Path constants below and their Windows
+	// scan/erase results. These must stay in sync with the paths the worker
+	// binaries open (see the *Path constants below and their Windows
 	// equivalents used by the worker on Windows nodes).
-	LinuxSharedDataPath   = "/run/eraser.sh/shared-data"
-	WindowsSharedDataPath = `C:\run\eraser.sh\shared-data`
+	LinuxSharedDataPath   = LinuxEraserPath + "/shared-data"
+	WindowsSharedDataPath = WindowsEraserPath + `\shared-data`
 
 	ScanErasePath            = LinuxSharedDataPath + "/scanErase"
 	CollectScanPath          = LinuxSharedDataPath + "/collectScan"

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -39,15 +39,6 @@ const (
 	EnvEraserRuntimeName = "ERASER_RUNTIME_NAME"
 )
 
-// SharedDataPathForOS returns the shared-data mount path appropriate for the
-// given node operating system (the value of the kubernetes.io/os label).
-func SharedDataPathForOS(osName string) string {
-	if strings.EqualFold(osName, "windows") {
-		return WindowsSharedDataPath
-	}
-	return LinuxSharedDataPath
-}
-
 type ExclusionList struct {
 	Excluded []string `json:"excluded"`
 }
@@ -57,6 +48,15 @@ var (
 	ErrEndpointDeprecated    = errors.New("endpoint is deprecated, please consider using full url format")
 	ErrOnlySupportUnixSocket = errors.New("only support unix socket endpoint")
 )
+
+// SharedDataPathForOS returns the shared-data mount path appropriate for the
+// given node operating system (the value of the kubernetes.io/os label).
+func SharedDataPathForOS(osName string) string {
+	if strings.EqualFold(osName, "windows") {
+		return WindowsSharedDataPath
+	}
+	return LinuxSharedDataPath
+}
 
 func GetConn(ctx context.Context, socketPath string) (conn *grpc.ClientConn, err error) {
 	addr, dialer, err := getAddressAndDialer(socketPath)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -35,6 +35,11 @@ const (
 	EraseCompleteScanPath    = LinuxSharedDataPath + "/eraseCompleteScan"
 
 	EnvEraserRuntimeName = "ERASER_RUNTIME_NAME"
+
+	// EnvEraserRuntimeAddress carries the CRI endpoint to Windows workers. The
+	// manager sets it from RuntimeSpec.WindowsAddress because a Windows named
+	// pipe cannot be hostPath-mounted the way a Linux socket is.
+	EnvEraserRuntimeAddress = "ERASER_RUNTIME_ADDRESS"
 )
 
 type ExclusionList struct {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -49,9 +49,9 @@ var (
 	ErrOnlySupportUnixSocket = errors.New("only support unix socket endpoint")
 )
 
-// SharedDataPathForOS returns the shared-data mount path appropriate for the
+// GetSharedDataPathForOS returns the shared-data mount path appropriate for the
 // given node operating system (the value of the kubernetes.io/os label).
-func SharedDataPathForOS(osName string) string {
+func GetSharedDataPathForOS(osName string) string {
 	if strings.EqualFold(osName, "windows") {
 		return WindowsSharedDataPath
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -49,15 +49,6 @@ var (
 	ErrOnlySupportUnixSocket = errors.New("only support unix socket endpoint")
 )
 
-// GetSharedDataPathForOS returns the shared-data mount path appropriate for the
-// given node operating system (the value of the kubernetes.io/os label).
-func GetSharedDataPathForOS(osName string) string {
-	if strings.EqualFold(osName, "windows") {
-		return WindowsSharedDataPath
-	}
-	return LinuxSharedDataPath
-}
-
 func GetConn(ctx context.Context, socketPath string) (conn *grpc.ClientConn, err error) {
 	addr, dialer, err := getAddressAndDialer(socketPath)
 	if err != nil {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -21,16 +21,37 @@ import (
 
 const (
 	// npipeProtocol is the network protocol of a Windows named pipe.
-	npipeProtocol            = "npipe"
-	PipeMode                 = 0o644
-	ScanErasePath            = "/run/eraser.sh/shared-data/scanErase"
-	CollectScanPath          = "/run/eraser.sh/shared-data/collectScan"
-	EraseCompleteCollectPath = "/run/eraser.sh/shared-data/eraseCompleteCollect"
+	npipeProtocol = "npipe"
+	PipeMode      = 0o644
+
+	// LinuxSharedDataPath and WindowsSharedDataPath are the in-container mount
+	// points of the shared-data emptyDir the worker containers use to exchange
+	// scan/erase results. The manager always runs on Linux but emits pod specs
+	// for both Linux and Windows nodes, so it needs both values as plain
+	// (non build-tagged) constants; a build-tagged constant would only expose
+	// the Linux value to the manager. These must stay in sync with the paths
+	// the worker binaries open (see the *Path constants below and their Windows
+	// equivalents used by the worker on Windows nodes).
+	LinuxSharedDataPath   = "/run/eraser.sh/shared-data"
+	WindowsSharedDataPath = `C:\run\eraser.sh\shared-data`
+
+	ScanErasePath            = LinuxSharedDataPath + "/scanErase"
+	CollectScanPath          = LinuxSharedDataPath + "/collectScan"
+	EraseCompleteCollectPath = LinuxSharedDataPath + "/eraseCompleteCollect"
 	EraseCompleteMessage     = "complete"
-	EraseCompleteScanPath    = "/run/eraser.sh/shared-data/eraseCompleteScan"
+	EraseCompleteScanPath    = LinuxSharedDataPath + "/eraseCompleteScan"
 
 	EnvEraserRuntimeName = "ERASER_RUNTIME_NAME"
 )
+
+// SharedDataPathForOS returns the shared-data mount path appropriate for the
+// given node operating system (the value of the kubernetes.io/os label).
+func SharedDataPathForOS(osName string) string {
+	if strings.EqualFold(osName, "windows") {
+		return WindowsSharedDataPath
+	}
+	return LinuxSharedDataPath
+}
 
 type ExclusionList struct {
 	Excluded []string `json:"excluded"`


### PR DESCRIPTION
### Description

Windows workers connect to containerd through a **named pipe** (`\\.\pipe\containerd-containerd`), which — unlike a Linux unix socket — cannot be `hostPath`-mounted into the worker. Because of that the Windows CRI endpoint was effectively hardcoded in the worker (`pkg/utils/platform_windows.go`) and the manager's Windows branch ignored `RuntimeSpec` entirely, leaving no way for users (including BYO / non-default containerd setups) to configure it.

This PR makes the Windows runtime address configurable and propagates it end-to-end:

- **add** — new `RuntimeSpec.WindowsAddress` config field (both `unversioned` and `v1alpha3`), validated (`npipe`/`tcp` schemes) and defaulting to the containerd named pipe when unset.
- **propagate** — the manager injects the resolved address into every Windows worker container via a new `ERASER_RUNTIME_ADDRESS` env var (a named pipe can't be mounted, so env is the HostProcess-compatible channel). The Windows worker reads it with a fallback to the default pipe.

Linux behavior is unchanged (it keeps using the hostPath socket mount).

Addresses reviewer feedback on #1236 (https://github.com/eraser-dev/eraser/pull/1236#discussion_r3874911387) — "add and propagate a Windows-specific runtime address".

> [!IMPORTANT]
> **Stacked on #1236.** This branch is based on `feat/windows-ready-imagejob-pods` (the manager Windows pod-spec work), so the diff shown here includes those commits until #1236 merges. Please review/merge #1236 first; this PR should be rebased onto `main` afterwards.

### Testing

- `api/unversioned`: default / custom `npipe` / `tcp` accepted / invalid scheme rejected.
- manager: Windows pods propagate the configured address to every worker via `ERASER_RUNTIME_ADDRESS`; no env injected when unset.
- Windows worker: `resolveCRIPath` honors the env override and falls back to the default pipe.