### PR TITLE
fix: update eraser install manifest to use stable v1.5.0 image

### DIFF
--- a/deploy/eraser.yaml
+++ b/deploy/eraser.yaml
@@ -443,7 +443,7 @@ data:
         enabled: true
         image:
           repo: ghcr.io/eraser-dev/collector
-          tag: v1.5.0-beta.0
+          tag: v1.5.0
         request:
           mem: 25Mi
           cpu: 7m
@@ -455,7 +455,7 @@ data:
         enabled: true
         image:
           repo: ghcr.io/eraser-dev/eraser-trivy-scanner # supply custom image for custom scanner
-          tag: v1.5.0-beta.0
+          tag: v1.5.0
         request:
           mem: 500Mi
           cpu: 1000m
@@ -493,7 +493,7 @@ data:
       remover:
         image:
           repo: ghcr.io/eraser-dev/remover
-          tag: v1.5.0-beta.0
+          tag: v1.5.0
         request:
           mem: 25Mi
           # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#how-pods-with-resource-limits-are-run
@@ -536,7 +536,7 @@ spec:
               fieldPath: metadata.namespace
         - name: OTEL_SERVICE_NAME
           value: eraser-manager
-        image: ghcr.io/eraser-dev/eraser-manager:v1.5.0-beta.0
+        image: ghcr.io/eraser-dev/eraser-manager:v1.5.0
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Fixes #1144

The deploy/eraser.yaml was pointing to v1.5.0-beta.0 instead of the
stable v1.5.0 release. Update all image references to use the stable
tag.