### PR TITLE
feat: add Windows HostProcess image stages for the collector and remover

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ ARG GO_IMAGE="golang:1.26.6-bookworm@sha256:116d58cbd88c1297624acc6e967a06001242
 # Use the upstream Trivy release image rather than rebuilding its binary with
 # local dependency overrides.
 ARG TRIVY_BINARY_IMG="ghcr.io/aquasecurity/trivy:0.72.0"
+# HostProcess base image for the Windows workers. It is around 22 kB because a
+# HostProcess container runs directly on the host and ships no OS of its own.
+ARG HPC_BASE_IMG="mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0"
 ARG BUILDKIT_SBOM_SCAN_STAGE=builder,manager-build,collector-build,remover-build,trivy-scanner-build
 
 FROM --platform=$TARGETPLATFORM $TRIVY_BINARY_IMG AS trivy-binary
@@ -58,13 +61,28 @@ COPY --from=manager-build /workspace/out/manager .
 USER 65532:65532
 ENTRYPOINT ["/manager"]
 
-FROM --platform=$TARGETPLATFORM gcr.io/distroless/static:latest as collector
+FROM --platform=$TARGETPLATFORM gcr.io/distroless/static:latest as collector-linux
 COPY --from=collector-build /workspace/out/collector /
 ENTRYPOINT ["/collector"]
 
-FROM --platform=$TARGETPLATFORM gcr.io/distroless/static:latest as remover
+# A HostProcess container runs on the host, so "/collector" would resolve against
+# the host filesystem. The image's own files are only reachable under the sandbox
+# mount point, and cmd.exe comes from the host.
+FROM --platform=windows/amd64 ${HPC_BASE_IMG} AS collector-windows
+COPY --from=collector-build /workspace/out/collector /collector.exe
+ENTRYPOINT ["cmd", "/c", "%CONTAINER_SANDBOX_MOUNT_POINT%\\collector.exe"]
+
+FROM collector-${TARGETOS} AS collector
+
+FROM --platform=$TARGETPLATFORM gcr.io/distroless/static:latest as remover-linux
 COPY --from=remover-build /workspace/out/remover /
 ENTRYPOINT ["/remover"]
+
+FROM --platform=windows/amd64 ${HPC_BASE_IMG} AS remover-windows
+COPY --from=remover-build /workspace/out/remover /remover.exe
+ENTRYPOINT ["cmd", "/c", "%CONTAINER_SANDBOX_MOUNT_POINT%\\remover.exe"]
+
+FROM remover-${TARGETOS} AS remover
 
 FROM --platform=$TARGETPLATFORM gcr.io/distroless/static:latest AS trivy-scanner
 COPY --from=trivy-scanner-build /workspace/out/trivy-scanner /


### PR DESCRIPTION
First of two for publishing Windows worker images. This one only adds the stages; nothing builds them until the follow-up changes the release platform string, so merging this alone is a no-op for what ships today.

## What changes

`collector` and `remover` each grow a Windows runtime stage on the HostProcess base image, and the existing distroless stage is renamed to `*-linux`. A trivial alias stage picks between them:

```dockerfile
FROM collector-${TARGETOS} AS collector
```

`manager` and `trivy-scanner` are untouched and stay Linux-only. The manager is a controller that runs on a Linux node, and the Trivy scanner has no Windows story.

## Two details worth explaining

**The base image.** `mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0`, about 22 kB. A HostProcess container runs directly on the host, so the image supplies no OS of its own — which is also why this doesn't tie the image to a specific Windows Server build the way `nanoserver:ltsc2022` would.

**The entrypoint is not the obvious one.**

```dockerfile
ENTRYPOINT ["cmd", "/c", "%CONTAINER_SANDBOX_MOUNT_POINT%\\remover.exe"]
```

`/remover` would resolve against the *host* filesystem, because that is what a HostProcess container sees. The image's own files are only reachable beneath the sandbox mount point, and `cmd.exe` comes from the host. This is the same form the manager already emits for the container command.

## No Windows runner is required

The Windows stages contain no `RUN`, only a `COPY` out of a Linux builder stage, so BuildKit assembles layers onto a Windows base without executing anything Windows. Verified on `ubuntu-latest`:

```text
#22 [linux/amd64->windows/amd64 remover-build 1/1] RUN ... GOOS=windows GOARCH=amd64 go build ... -o out/remover ./pkg/remover
```

## Testing

Upstream CI already exercises this change: `e2e-build.yaml` and `scan-images.yaml` both call `make docker-build-remover` / `-collector` without setting `PLATFORM`, so they build through the new conditional `FROM` on every PR at the default `PLATFORM=linux`.

The multi-platform path is not reachable from upstream CI — `release.yaml` is the only caller that sets `PLATFORM`, and it only runs on a tag. So it was verified on a fork ([run 33704981762](https://github.com/charleswool/eraser/actions/runs/33704981762)), using the exact invocation `release.yaml` uses:

| Job | Result |
|---|---|
| `make docker-build-remover PLATFORM="linux/amd64,windows/amd64" GENERATE_ATTESTATIONS=true` | pass |
| `make docker-build-collector` same | pass |
| `make docker-build-manager PLATFORM="linux/amd64,linux/arm64"` — unchanged path | pass |
| default `PLATFORM`, as `e2e-build.yaml` calls it | pass |

The resulting index:

```text
linux/amd64      image
windows/amd64    image
unknown/unknown  attestation-manifest
unknown/unknown  attestation-manifest
```

Both platforms under one tag, with SBOM and provenance attestations intact — that last part was the open question, since attestations have only ever run over Linux-only indexes.

## One thing this does not fix

`BUILDKIT_SBOM_SCAN_STAGE` lists `builder,manager-build,collector-build,remover-build,trivy-scanner-build`. Those are all Linux stages on the `golang:1.26.6-bookworm` builder, because that is where the compilation happens. The SBOM attached to the Windows image therefore describes a Debian toolchain rather than a Windows image, and adding the Windows stages to that list would not help — they have no packages, only a copied binary.

That is a reporting question rather than a build one, and I have not tried to solve it here. Flagging it because it is the likely cause of any OS/distro metadata complaints from downstream SBOM consumers.
